### PR TITLE
Fix typo in state censorship example

### DIFF
--- a/examples/state-censorship.argdown
+++ b/examples/state-censorship.argdown
@@ -26,7 +26,7 @@ Two central claims
 
 [Censorship]: Censorship is not wrong in principle.
 
-[Absolute Freedom of Speech]: Freedom of speech is an
+[Absolute Freedom of Speech]: Freedom of speech is an 
 absolute right.
 
 


### PR DESCRIPTION
added space between "an" and "absolute"