### PR TITLE
Adding execution capability to the language server via npx

### DIFF
--- a/.changeset/wacky-hotels-travel.md
+++ b/.changeset/wacky-hotels-travel.md
@@ -1,0 +1,5 @@
+---
+"@argdown/language-server": patch
+---
+
+npx executable

--- a/packages/argdown-language-server/package.json
+++ b/packages/argdown-language-server/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "author": "Christian Voigt",
   "license": "MIT",
+  "bin": "./dist/server.node.js",
   "main": "./dist/server.node.js",
   "browser": "./dist/server.browser.js",
   "files": [

--- a/packages/argdown-language-server/src/server.node.ts
+++ b/packages/argdown-language-server/src/server.node.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { createConnection, ProposedFeatures } from "vscode-languageserver/node";
 import { Server } from "./server.common";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,8 @@ __metadata:
     vitest: "npm:^4.1.0"
     vscode-languageserver: "npm:^9.0.1"
     vscode-languageserver-textdocument: "npm:1.0.12"
+  bin:
+    language-server: ./dist/server.node.js
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18580,7 +18580,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.10, postcss@npm:^8.5.6":
+"postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.6":
+  version: 8.5.6
+  resolution: "postcss@npm:8.5.6"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.10":
   version: 8.5.10
   resolution: "postcss@npm:8.5.10"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -18580,18 +18580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.6":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.10":
+"postcss@npm:^8.4.33, postcss@npm:^8.4.43, postcss@npm:^8.5.10, postcss@npm:^8.5.6":
   version: 8.5.10
   resolution: "postcss@npm:8.5.10"
   dependencies:


### PR DESCRIPTION
This closes #566 by marking the language server as executable in a node environment.

# You can test this:
```bash
git fetch origin
git checkout 566-cli-command-for-lsp-server
yarn install
yarn build
cd packages/argdown-language-server
npm link
// In another directory or a lsp client (e.g opencode):
npx @argdown/language-server --stdio 
```