### PR TITLE
Multifile Argdown

### DIFF
--- a/packages/argdown-core/src/RuleNames.ts
+++ b/packages/argdown-core/src/RuleNames.ts
@@ -31,5 +31,6 @@ export enum RuleNames {
   OUTGOING_UNDERCUT = "outgoingUndercut",
   BOLD = "bold",
   ITALIC = "italic",
-  FREESTYLE_TEXT = "freestyleText"
+  FREESTYLE_TEXT = "freestyleText",
+  INCLUDE = "include",
 }

--- a/packages/argdown-core/src/TokenNames.ts
+++ b/packages/argdown-core/src/TokenNames.ts
@@ -45,5 +45,6 @@ export enum TokenNames {
   ESCAPED_CHAR = "EscapedChar",
   SPECIAL_CHAR = "SpecialChar",
   SPACES = "Spaces",
-  EOF = "EOF"
+  EOF = "EOF",
+  INCLUDE = "Include",
 }

--- a/packages/argdown-core/src/argdown.ts
+++ b/packages/argdown-core/src/argdown.ts
@@ -21,6 +21,7 @@ import { ExplodeArgumentsPlugin } from "./plugins/ExplodeArgumentsPlugin.js";
 import { MapNodeImagesPlugin } from "./plugins/MapNodeImagesPlugin.js";
 
 import { Graphviz } from "@hpcc-js/wasm-graphviz";
+import { IncludePositionsPlugin } from "./plugins/IncludePositionsPlugin.js";
 /***
  * Default instance of a sync ArgdownApplication with all plugins of @argdown/core loaded and default processes defined.
  *
@@ -46,6 +47,7 @@ argdown.addPlugin(new DotExportPlugin(), "export-dot");
 argdown.addPlugin(new GraphMLExportPlugin(), "export-graphml");
 argdown.addPlugin(new HighlightSourcePlugin(), "highlight-source");
 argdown.addPlugin(new WebComponentExportPlugin(), "export-web-component");
+argdown.addPlugin(new IncludePositionsPlugin(), "include-positions");
 
 /**
  * Initializes the argdown application by loading Graphviz and adding the SyncDotToSvgExportPlugin.

--- a/packages/argdown-core/src/index.ts
+++ b/packages/argdown-core/src/index.ts
@@ -168,3 +168,4 @@ export * from "./model/model.js";
 export * from "./model/toJSON.js";
 export * from "./utils.js";
 export * from "./deriveImplicitRelations.js";
+export * from "./plugins/IncludePositionsPlugin.js"

--- a/packages/argdown-core/src/lexer.ts
+++ b/packages/argdown-core/src/lexer.ts
@@ -764,7 +764,7 @@ export const UnusedControlChar = createToken({
 tokenList.push(UnusedControlChar);
 
 
-const includePattern = /@include\(\s*(?<path>(?:[^/)\s]*\/)*)(?<name>[^)\s]*?)(?<extension>\.(ad|argdown|adown|argdn))?\s*\)/y;
+const includePattern = /@include\(\s*(?<filePath>(?<path>(?:[^/)\s]*\/)*)(?<name>[^)\s]*?)(?<extension>\.(ad|argdown|adown|argdn))?)\s*\)/y;
 const matchInclude: chevrotain.CustomPatternMatcherFunc = (text: string, startOffset: number) => {
   includePattern.lastIndex = startOffset;
   const res = includePattern.exec(text);

--- a/packages/argdown-core/src/lexer.ts
+++ b/packages/argdown-core/src/lexer.ts
@@ -763,6 +763,22 @@ export const UnusedControlChar = createToken({
 });
 tokenList.push(UnusedControlChar);
 
+
+const includePattern = /@include\(\s*(?<path>(?:[^/)\s]*\/)*)(?<name>[^)\s]*?)(?<extension>\.(ad|argdown|adown|argdn))?\s*\)/y;
+const matchInclude: chevrotain.CustomPatternMatcherFunc = (text: string, startOffset: number) => {
+  includePattern.lastIndex = startOffset;
+  const res = includePattern.exec(text);
+  if (!res) return null;
+  return {...res, payload: res.groups};
+}
+export const Include = createToken({
+  name: TokenNames.INCLUDE,
+  pattern: matchInclude,
+  label: "@include(<filePath><fileName><fileExtension>)",
+  line_breaks: true,
+});
+tokenList.push(Include);
+
 export const EOF = chevrotain.EOF;
 
 const lexerConfig: chevrotain.IMultiModeLexerDefinition = {
@@ -804,6 +820,7 @@ const lexerConfig: chevrotain.IMultiModeLexerDefinition = {
       UnderscoreItalicStart,
       Link, //needs to be lexed before StatementReference
       Tag,
+      Include,
       // $.StatementDefinitionByNumber, // needs to be lexed before ArgumentReference
       // $.StatementReferenceByNumber, // needs to be lexed before ArgumentReference
       // $.StatementMentionByNumber, // needs to be lexed before ArgumentReference

--- a/packages/argdown-core/src/parser.ts
+++ b/packages/argdown-core/src/parser.ts
@@ -46,26 +46,29 @@ class ArgdownParser extends EmbeddedActionsParser {
         atLeastOne.push(
           this.OR2(
             this.c1 ||
-              (this.c1 = [
-                {
-                  ALT: () => this.SUBRULE(this.heading)
-                },
-                {
-                  ALT: () => this.SUBRULE(this.statement)
-                },
-                {
-                  ALT: () => this.SUBRULE(this.pcs)
-                },
-                {
-                  ALT: () => this.SUBRULE(this.argument)
-                },
-                {
-                  ALT: () => this.SUBRULE(this.orderedList)
-                },
-                {
-                  ALT: () => this.SUBRULE(this.unorderedList)
-                }
-              ])
+            (this.c1 = [
+              {
+                ALT: () => this.SUBRULE(this.heading)
+              },
+              {
+                ALT: () => this.SUBRULE(this.statement)
+              },
+              {
+                ALT: () => this.SUBRULE(this.pcs)
+              },
+              {
+                ALT: () => this.SUBRULE(this.argument)
+              },
+              {
+                ALT: () => this.SUBRULE(this.orderedList)
+              },
+              {
+                ALT: () => this.SUBRULE(this.unorderedList)
+              },
+              {
+                ALT: () => this.SUBRULE(this.include)
+              }
+            ])
           )
         );
       }
@@ -288,29 +291,29 @@ class ArgdownParser extends EmbeddedActionsParser {
       children.push(
         this.OR(
           this.c2 ||
-            (this.c2 = [
-              {
-                ALT: () => this.SUBRULE(this.incomingSupport)
-              },
-              {
-                ALT: () => this.SUBRULE(this.incomingAttack)
-              },
-              {
-                ALT: () => this.SUBRULE(this.outgoingSupport)
-              },
-              {
-                ALT: () => this.SUBRULE(this.outgoingAttack)
-              },
-              {
-                ALT: () => this.SUBRULE(this.contradiction)
-              },
-              {
-                ALT: () => this.SUBRULE(this.incomingUndercut)
-              },
-              {
-                ALT: () => this.SUBRULE(this.outgoingUndercut)
-              }
-            ])
+          (this.c2 = [
+            {
+              ALT: () => this.SUBRULE(this.incomingSupport)
+            },
+            {
+              ALT: () => this.SUBRULE(this.incomingAttack)
+            },
+            {
+              ALT: () => this.SUBRULE(this.outgoingSupport)
+            },
+            {
+              ALT: () => this.SUBRULE(this.outgoingAttack)
+            },
+            {
+              ALT: () => this.SUBRULE(this.contradiction)
+            },
+            {
+              ALT: () => this.SUBRULE(this.incomingUndercut)
+            },
+            {
+              ALT: () => this.SUBRULE(this.outgoingUndercut)
+            }
+          ])
         )
       );
     });
@@ -448,36 +451,36 @@ class ArgdownParser extends EmbeddedActionsParser {
       children.push(
         this.OR(
           this.c3 ||
-            (this.c3 = [
-              {
-                ALT: () => this.SUBRULE(this.freestyleText)
-              },
-              {
-                ALT: () => this.CONSUME(lexer.Link)
-              },
-              {
-                ALT: () => this.SUBRULE(this.bold)
-              },
-              {
-                ALT: () => this.SUBRULE(this.italic)
-              },
-              {
-                ALT: () => this.CONSUME(lexer.Tag)
-              },
-              {
-                ALT: () => this.CONSUME(lexer.ArgumentMention)
-              },
-              {
-                ALT: () => this.CONSUME(lexer.StatementMention)
-              },
-              {
-                ALT: () => this.CONSUME(lexer.Newline)
-              }
+          (this.c3 = [
+            {
+              ALT: () => this.SUBRULE(this.freestyleText)
+            },
+            {
+              ALT: () => this.CONSUME(lexer.Link)
+            },
+            {
+              ALT: () => this.SUBRULE(this.bold)
+            },
+            {
+              ALT: () => this.SUBRULE(this.italic)
+            },
+            {
+              ALT: () => this.CONSUME(lexer.Tag)
+            },
+            {
+              ALT: () => this.CONSUME(lexer.ArgumentMention)
+            },
+            {
+              ALT: () => this.CONSUME(lexer.StatementMention)
+            },
+            {
+              ALT: () => this.CONSUME(lexer.Newline)
+            }
 
-              // , {
-              //     ALT: () => children.push(this.CONSUME(lexer.StatementMentionByNumber))
-              // }
-            ])
+            // , {
+            //     ALT: () => children.push(this.CONSUME(lexer.StatementMentionByNumber))
+            // }
+          ])
         )
       );
       // this.OPTION1(() => {
@@ -507,5 +510,17 @@ class ArgdownParser extends EmbeddedActionsParser {
     );
     return IRuleNode.create(RuleNames.FREESTYLE_TEXT, children);
   });
+
+  private include = this.RULE(RuleNames.INCLUDE, () => {
+    const children: IAstNode[] = [];
+    const includeToken = this.CONSUME1(lexer.Include);
+    children.push(includeToken);
+    this.OPTION1(() => {
+      children.push(this.CONSUME1(lexer.Newline));
+    });
+    return IRuleNode.create(RuleNames.INCLUDE, children);
+  });
 }
+
+
 export const parser = new ArgdownParser();

--- a/packages/argdown-core/src/plugins/IncludePositionsPlugin.ts
+++ b/packages/argdown-core/src/plugins/IncludePositionsPlugin.ts
@@ -1,8 +1,8 @@
-import { checkResponseFields, IArgdownPlugin, IRequestHandler, IRuleNode, RuleNames } from "../index.js";
+import { checkResponseFields, IArgdownPlugin, IRequestHandler, IRuleNode, ITokenNode, RuleNames } from "../index.js";
 
 declare module "../index.js" {
   interface IArgdownResponse {
-    includes?: IRuleNode[];
+    includes?: ITokenNode[];
   }
 }
 
@@ -12,7 +12,8 @@ export class IncludePositionsPlugin implements IArgdownPlugin {
     checkResponseFields(this, response, ["ast"])
     const ast = response.ast as IRuleNode;
     if (!ast.children) return;
-    const includeNodes = ast.children.filter((x) => (x as IRuleNode).name === RuleNames.INCLUDE)
-    response.includes = includeNodes as IRuleNode[];
+    const includeNodes = ast.children.filter((x) => (x as IRuleNode).name === RuleNames.INCLUDE).flatMap(x => (x as IRuleNode).children).filter(x => (x as ITokenNode).tokenType.name === "Include");
+
+    response.includes = includeNodes as ITokenNode[];
   };
 }

--- a/packages/argdown-core/src/plugins/IncludePositionsPlugin.ts
+++ b/packages/argdown-core/src/plugins/IncludePositionsPlugin.ts
@@ -1,0 +1,18 @@
+import { checkResponseFields, IArgdownPlugin, IRequestHandler, IRuleNode, RuleNames } from "../index.js";
+
+declare module "../index.js" {
+  interface IArgdownResponse {
+    includes?: IRuleNode[];
+  }
+}
+
+export class IncludePositionsPlugin implements IArgdownPlugin {
+  name: string = "IncludePositionsPlugin";
+  run: IRequestHandler = (_, response) => {
+    checkResponseFields(this, response, ["ast"])
+    const ast = response.ast as IRuleNode;
+    if (!ast.children) return;
+    const includeNodes = ast.children.filter((x) => (x as IRuleNode).name === RuleNames.INCLUDE)
+    response.includes = includeNodes as IRuleNode[];
+  };
+}

--- a/packages/argdown-core/test/IncludePositionsPlugin.spec.ts
+++ b/packages/argdown-core/test/IncludePositionsPlugin.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import {
+  ArgdownApplication,
+  IncludePositionsPlugin,
+  ParserPlugin,
+  RuleNames
+} from "../src/index";
+
+let app = new ArgdownApplication();
+
+describe("IncludePositionsPlugin", function () {
+  const parserPlugin = new ParserPlugin();
+  const includePlugin = new IncludePositionsPlugin();
+  app.addPlugin(parserPlugin, "parse-input");
+
+  app.addPlugin(includePlugin, "include-positions");
+
+  it("can parse includes", function () {
+    const source = `
+<B> {auf: wiedersehen}
+
+@include(file.argdown)
+
+<?-- @include(file2.argdown) -->
+
+@include(../file.ad)
+`;
+    const request = {
+      process: ["parse-input", "include-positions"],
+      input: source,
+      logLevel: "error",
+    };
+    const result = app.run(request);
+    console.log(JSON.stringify(result.includes, null, 2));
+    expect(result.parserErrors!.length).to.equal(0);
+    expect(result.lexerErrors!.length).to.equal(0);
+
+    expect(result.includes!.length).to.equal(2);
+    expect(result.includes!.every((node) => node.name === RuleNames.INCLUDE)).to.be.true;
+  });
+});

--- a/packages/argdown-core/test/IncludePositionsPlugin.spec.ts
+++ b/packages/argdown-core/test/IncludePositionsPlugin.spec.ts
@@ -37,6 +37,6 @@ describe("IncludePositionsPlugin", function () {
     expect(result.lexerErrors!.length).to.equal(0);
 
     expect(result.includes!.length).to.equal(2);
-    expect(result.includes!.every((node) => node.name === RuleNames.INCLUDE)).to.be.true;
+    expect(result.includes!.every((node) => node.tokenType.name === "Include")).to.be.true;
   });
 });

--- a/packages/argdown-core/test/lexer-parser-include.argdown
+++ b/packages/argdown-core/test/lexer-parser-include.argdown
@@ -1,0 +1,8 @@
+Some text here
+
+@include(file.argdown)
+
+Another statement @include(path/to/file.argdown)
+
+<A>: Statement with include
+@include(../relative/path.argdown)

--- a/packages/argdown-core/test/lexer.spec.ts
+++ b/packages/argdown-core/test/lexer.spec.ts
@@ -778,6 +778,57 @@ p:->:q
     expect(result.tokens.length).to.equal(1);
     expectToken(lexer.ArgumentReference);
   });
+
+  it("can recognize include tokens", function () {
+    let source = fs.readFileSync("./test/lexer-parser-include.argdown", "utf8");
+    const result = lexer.tokenize(source);
+    startTest(result.tokens);
+    expectToken(lexer.Freestyle); // "Some text here"
+    expectToken(lexer.Emptyline);
+    expectToken(lexer.Include); // @include(file.argdown)
+    expectToken(lexer.Emptyline);
+    expectToken(lexer.Freestyle); // "Another statement"
+    expectToken(lexer.Include); // @include(path/to/file.argdown)
+    expectToken(lexer.Emptyline);
+    expectToken(lexer.ArgumentDefinition); // <A>:
+    expectToken(lexer.Freestyle);
+    expectToken(lexer.Newline);
+    expectToken(lexer.Include); // @include(../relative/path.argdown)
+  });
+
+  it("can lex single include token", function () {
+    let source = `@include(test.argdown)`;
+    const result = lexer.tokenize(source);
+    expect(result.errors).to.be.empty;
+    expect(result.tokens.length).to.equal(1);
+    expect(result.tokens[0].payload.path).to.equal("");
+    expect(result.tokens[0].payload.name).to.equal("test");
+    expect(result.tokens[0].payload.extension).to.equal(".argdown");
+    expect(result.tokens[0].tokenType.name).to.equal("Include");
+    expect(result.tokens[0].image).to.equal("@include(test.argdown)");
+  });
+
+  it("can lex single empty include token", function () {
+    let source = `@include()`;
+    const result = lexer.tokenize(source);
+    expect(result.errors).to.be.empty;
+    expect(result.tokens.length).to.equal(1);
+    expect(result.tokens[0].tokenType.name).to.equal("Include");
+    expect(result.tokens[0].image).to.equal("@include()");
+  });
+
+  it("can lex include with path", function () {
+    let source = `@include(../path/to/file.argdown)`;
+    const result = lexer.tokenize(source);
+    expect(result.errors).to.be.empty;
+    expect(result.tokens.length).to.equal(1);
+    console.log(result.tokens[0].payload)
+    expect(result.tokens[0].tokenType.name).to.equal("Include");
+    expect(result.tokens[0].payload.path).to.equal("../path/to/");
+    expect(result.tokens[0].payload.name).to.equal("file");
+    expect(result.tokens[0].payload.extension).to.equal(".argdown");
+    expect(result.tokens[0].image).to.equal("@include(../path/to/file.argdown)");
+  });
   //   it("can ignore Newline in Newline Comment Emptyline", function() {
   //     let source = `
   // /* Comment */

--- a/packages/argdown-core/test/lexer.spec.ts
+++ b/packages/argdown-core/test/lexer.spec.ts
@@ -822,7 +822,6 @@ p:->:q
     const result = lexer.tokenize(source);
     expect(result.errors).to.be.empty;
     expect(result.tokens.length).to.equal(1);
-    console.log(result.tokens[0].payload)
     expect(result.tokens[0].tokenType.name).to.equal("Include");
     expect(result.tokens[0].payload.path).to.equal("../path/to/");
     expect(result.tokens[0].payload.name).to.equal("file");

--- a/packages/argdown-core/test/parser.spec.ts
+++ b/packages/argdown-core/test/parser.spec.ts
@@ -410,6 +410,73 @@ B: asdasdds
     expect(lexResult.errors).to.be.empty;
     expect(parser.errors).to.be.empty;
   });
+
+  it("can parse include directive", function () {
+    let source = `@include(test.argdown)`;
+    let lexResult = tokenize(source);
+    parser.input = lexResult.tokens;
+    let ast = parser.argdown();
+    const childs = ast.children;
+    expect(lexResult.errors).to.be.empty;
+    console.log(parser.errors)
+    expect(parser.errors).to.be.empty;
+    expect(childs).to.be.an("array");
+    expect(childs?.length).to.equal(1);
+    const node = childs?.at(0) as IRuleNode;
+    console.log(node)
+    expect(node.name).to.equal("include");
+    expect(node.children?.length).to.equal(1);
+    const child = node.children?.at(0) as ITokenNode;
+    expect(child.image).to.equal("@include(test.argdown)");
+  });
+
+  it("can parse multiple includes", function () {
+    let source = `
+  @include(file1.argdown)
+
+  @include(file2.argdown)
+  `;
+    let lexResult = tokenize(source);
+    parser.input = lexResult.tokens;
+    let ast = parser.argdown();
+    console.log(lexResult.errors, parser.errors)
+    expect(lexResult.errors).to.be.empty;
+    expect(parser.errors).to.be.empty;
+    expect(ast.children!.length).to.equal(2);
+    expect((ast.children![0] as IRuleNode).name).to.equal("include");
+    expect((ast.children![1] as IRuleNode).name).to.equal("include");
+  });
+
+  it("can parse include mixed with statements", function () {
+    let source = `
+  Statement A
+
+  @include(related.argdown)
+
+  <B>: Statement B
+  `;
+    let lexResult = tokenize(source);
+    parser.input = lexResult.tokens;
+    let ast = parser.argdown();
+    expect(lexResult.errors).to.be.empty;
+    expect(parser.errors).to.be.empty;
+    expect(ast.children!.length).to.equal(3);
+    expect((ast.children![0] as IRuleNode).name).to.equal("statement");
+    expect((ast.children![1] as IRuleNode).name).to.equal("include");
+    expect((ast.children![2] as IRuleNode).name).to.equal("argument");
+  });
+
+  it("can parse include with complex path", function () {
+    let source = `@include(../complex/path-with-dash/file_name.argdown)`;
+    let lexResult = tokenize(source);
+    parser.input = lexResult.tokens;
+    let ast = parser.argdown();
+    expect(lexResult.errors).to.be.empty;
+    expect(parser.errors).to.be.empty;
+    expect(ast.children!.length).to.equal(1);
+    expect((ast.children![0] as IRuleNode).name).to.equal("include");
+    expect(((ast.children![0] as IRuleNode).children![0] as ITokenNode).tokenType.name).to.equal("Include");
+  });
   //   it("can parse nested lists", () => {
   //     const input = `
   // # The central statements of the debate

--- a/packages/argdown-core/test/parser.spec.ts
+++ b/packages/argdown-core/test/parser.spec.ts
@@ -62,7 +62,6 @@ describe("Parser", function () {
     // console.log(astToString(ast));
     // console.log(astToJsonString(ast));
     expect(lexResult.errors).to.be.empty;
-    console.log(parser.errors);
     expect(parser.errors).to.be.empty;
   });
   it("can parse relation with subsequent comment", function () {
@@ -418,12 +417,10 @@ B: asdasdds
     let ast = parser.argdown();
     const childs = ast.children;
     expect(lexResult.errors).to.be.empty;
-    console.log(parser.errors)
     expect(parser.errors).to.be.empty;
     expect(childs).to.be.an("array");
     expect(childs?.length).to.equal(1);
     const node = childs?.at(0) as IRuleNode;
-    console.log(node)
     expect(node.name).to.equal("include");
     expect(node.children?.length).to.equal(1);
     const child = node.children?.at(0) as ITokenNode;
@@ -439,7 +436,6 @@ B: asdasdds
     let lexResult = tokenize(source);
     parser.input = lexResult.tokens;
     let ast = parser.argdown();
-    console.log(lexResult.errors, parser.errors)
     expect(lexResult.errors).to.be.empty;
     expect(parser.errors).to.be.empty;
     expect(ast.children!.length).to.equal(2);

--- a/packages/argdown-language-server/package.json
+++ b/packages/argdown-language-server/package.json
@@ -41,7 +41,7 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "vitest": "^4.1.7",
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.1.0",
     "vscode-languageserver-textdocument": "1.0.12"
   },
   "packageManager": "yarn@4.9.4",

--- a/packages/argdown-language-server/package.json
+++ b/packages/argdown-language-server/package.json
@@ -44,5 +44,9 @@
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "1.0.12"
   },
-  "packageManager": "yarn@4.9.4"
+  "packageManager": "yarn@4.9.4",
+  "dependencies": {
+    "fast-glob": "^3.3.3",
+    "vscode-uri": "^3.1.0"
+  }
 }

--- a/packages/argdown-language-server/src/ArgdownEngine.common.ts
+++ b/packages/argdown-language-server/src/ArgdownEngine.common.ts
@@ -1,0 +1,134 @@
+import { argdown, IArgdownRequest } from "@argdown/core";
+import {
+  Connection,
+  Diagnostic,
+  DiagnosticSeverity,
+  DocumentSymbol,
+  DocumentUri,
+  FoldingRange,
+  Range,
+  TextDocument,
+  TextDocumentIdentifier
+} from "vscode-languageserver";
+import { IArgdownSettings } from "./IArgdownSettings";
+import { DocumentSymbolPlugin } from "./providers/DocumentSymbolPlugin";
+import { FoldingRangesPlugin } from "./providers/FoldingRangesPlugin";
+
+export abstract class ArgdownEngine {
+  protected argdown = argdown;
+  private loglevel = "verbose";
+
+  protected abstract connection: Connection;
+
+  protected documentSettings: Map<string, Thenable<IArgdownSettings>> =
+    new Map();
+
+  constructor() {
+    this.argdown.addPlugin(new DocumentSymbolPlugin(), "add-document-symbols");
+    this.argdown.addPlugin(new FoldingRangesPlugin(), "add-folding-ranges");
+    this.addLogger();
+  }
+
+  protected abstract getDocument(uri: DocumentUri): TextDocument;
+
+  private addLogger() {
+    this.argdown.logger = {
+      setLevel: (level: string) => {
+        this.loglevel = level;
+      },
+      log: (_level: string, message: string) => {
+        if (this.loglevel === "verbose") {
+          this.connection.console.log(message);
+        }
+      }
+    };
+  }
+
+  protected validateTextDocument(textDocument: TextDocument): void {
+    const text = textDocument.getText();
+    const result = this.argdown.run({
+      process: ["parse-input", "build-model"],
+      input: text
+    });
+
+    const diagnostics: Diagnostic[] =
+      result.parserErrors
+        ?.map(
+          ({
+            message,
+            token: { startLine, startColumn, endLine, endColumn }
+          }) => {
+            if (!startLine || !startColumn || !endLine || !endColumn) return; // Should never happen
+            const start = {
+              line: startLine - 1,
+              character: startColumn - 1
+            };
+            const end = {
+              line: endLine - 1,
+              character: endColumn
+            }; //end character is zero based, exclusive
+            const range = Range.create(start, end);
+            const severity = DiagnosticSeverity.Error;
+            return Diagnostic.create(range, message, severity, "argdown");
+          }
+        )
+        .filter((x): x is Diagnostic => !!x) ?? [];
+
+    // Send the computed diagnostics to VSCode.
+    void this.connection.sendDiagnostics({
+      uri: textDocument.uri,
+      diagnostics
+    });
+  }
+  protected processTextForProviders(text: string) {
+    const request: IArgdownRequest = {
+      input: text,
+      process: ["parse-input", "build-model"],
+      throwExceptions: true,
+      parser: {
+        throwExceptions: true
+      }
+    };
+    try {
+      return this.argdown.run(request);
+    } catch {
+      return null;
+    }
+  }
+  protected processDocForProviders(textDocument: TextDocumentIdentifier) {
+    const doc = this.getDocument(textDocument.uri);
+    if (doc) {
+      const text = doc.getText();
+      return this.processTextForProviders(text);
+    }
+    return null;
+  }
+
+  protected getDocumentSymbols(text: string): DocumentSymbol[] | null {
+    const request: IArgdownRequest = {
+      input: text,
+      process: ["parse-input", "build-model", "add-document-symbols"],
+      parser: { throwExceptions: true },
+      throwExceptions: true
+    };
+    try {
+      return this.argdown.run(request).documentSymbols ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  protected getFoldingRanges(text: string): FoldingRange[] | null {
+    const request: IArgdownRequest = {
+      input: text,
+      process: ["parse-input", "build-model", "add-folding-ranges"],
+      parser: { throwExceptions: true },
+      throwExceptions: true
+    };
+    try {
+      return this.argdown.run(request).foldingRanges ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/argdown-language-server/src/ArgdownEngine.common.ts
+++ b/packages/argdown-language-server/src/ArgdownEngine.common.ts
@@ -80,7 +80,7 @@ export abstract class ArgdownEngine {
       diagnostics
     });
   }
-  protected processTextForProviders(text: string) {
+  private processTextForProviders(text: string) {
     const request: IArgdownRequest = {
       input: text,
       process: ["parse-input", "build-model"],
@@ -95,18 +95,20 @@ export abstract class ArgdownEngine {
       return null;
     }
   }
-  protected processDocForProviders(textDocument: TextDocumentIdentifier) {
+  protected doc2String(
+    textDocument: TextDocumentIdentifier
+  ): string | Promise<string> {
     const doc = this.getDocument(textDocument.uri);
-    if (doc) {
-      const text = doc.getText();
-      return this.processTextForProviders(text);
-    }
-    return null;
+    if (!doc) return null;
+    return doc.getText();
+  }
+  protected async processDocForProviders(textDocument: TextDocumentIdentifier) {
+    return this.processTextForProviders(await this.doc2String(textDocument));
   }
 
-  protected getDocumentSymbols(text: string): DocumentSymbol[] | null {
+  protected async getDocumentSymbols(textDocument: TextDocumentIdentifier) {
     const request: IArgdownRequest = {
-      input: text,
+      input: await this.doc2String(textDocument),
       process: ["parse-input", "build-model", "add-document-symbols"],
       parser: { throwExceptions: true },
       throwExceptions: true
@@ -118,9 +120,9 @@ export abstract class ArgdownEngine {
     }
   }
 
-  protected getFoldingRanges(text: string): FoldingRange[] | null {
+  protected async getFoldingRanges(textDocument: TextDocumentIdentifier) {
     const request: IArgdownRequest = {
-      input: text,
+      input: await this.doc2String(textDocument),
       process: ["parse-input", "build-model", "add-folding-ranges"],
       parser: { throwExceptions: true },
       throwExceptions: true

--- a/packages/argdown-language-server/src/CompileArgdown.ts
+++ b/packages/argdown-language-server/src/CompileArgdown.ts
@@ -1,0 +1,53 @@
+export class CompileArgdown {
+  /**
+   * Loads a file from the given path, relative to the `from` path.
+   * @param path The relative or absolute path of the file to load.
+   * @param from The absolute path of the file that is including this file.
+   * @returns A tuple containing the unique file id (e.g. absolute path of the file) and content.
+   */
+  private loadfile: (path: string, from: string) => Promise<[string, string]>;
+  /**
+   *
+   * @param loadfile see {@link CompilePlugin.loadfile}
+   */
+  constructor(
+    loadfile: (path: string, from: string) => Promise<[string, string]>
+  ) {
+    this.loadfile = loadfile;
+  }
+
+  // Recursively compiles the input string, replacing @include directives with the contents of the included files. Depth-first, not-parallel.
+  public async compile(
+    input: string,
+    from: string,
+    alreadyIncluded: Set<string> = new Set()
+  ): Promise<string> {
+    const regex: RegExp = /@include\(([^)]+)\)/g;
+    const matches = Array.from(input.matchAll(regex));
+    if (matches.length === 0) return input;
+    const loads = await Promise.all(
+      matches.map(async (match) => {
+        const name = match[1];
+        let id, content;
+        try {
+          [id, content] = await this.loadfile(name, from);
+        } catch {
+          const lineNumber =
+            input.split("\n").findIndex((line) => line.includes(name)) + 1;
+
+          return `<!-- File ${name} not found. Is included by ${from}:${lineNumber} -->`;
+          // throw new Error(
+          //   `File ${name} not found. Is included by ${from}:${lineNumber}.`
+          // );
+        }
+        if (!id || !content) return `<!-- Empty content: ${name} -->`;
+        if (alreadyIncluded.has(id)) {
+          return `<!-- Already included: ${id} -->`;
+        }
+        alreadyIncluded.add(id);
+        return `<!-- Start: ${id} -->\n${await this.compile(content, id, alreadyIncluded)}\n<!-- End: ${id} -->`;
+      })
+    );
+    return input.replace(regex, () => loads.shift() || "");
+  }
+}

--- a/packages/argdown-language-server/src/CompileArgdown.ts
+++ b/packages/argdown-language-server/src/CompileArgdown.ts
@@ -1,4 +1,8 @@
+import { argdown } from "@argdown/core";
+
 export class CompileArgdown {
+
+  private argdown = argdown;
   /**
    * Loads a file from the given path, relative to the `from` path.
    * @param path The relative or absolute path of the file to load.
@@ -8,7 +12,7 @@ export class CompileArgdown {
   private loadfile: (path: string, from: string) => Promise<[string, string]>;
   /**
    *
-   * @param loadfile see {@link CompilePlugin.loadfile}
+   * @param loadfile see {@link CompileArgdown.loadfile}
    */
   constructor(
     loadfile: (path: string, from: string) => Promise<[string, string]>
@@ -22,23 +26,19 @@ export class CompileArgdown {
     from: string,
     alreadyIncluded: Set<string> = new Set()
   ): Promise<string> {
-    const regex: RegExp = /@include\(([^)]+)\)/g;
-    const matches = Array.from(input.matchAll(regex));
-    if (matches.length === 0) return input;
+    const { includes } = this.argdown.run({
+      process: ["parse-input", "include-positions"],
+      input
+    });
+    if (!includes || includes.length === 0) return input;
     const loads = await Promise.all(
-      matches.map(async (match) => {
-        const name = match[1];
+      includes.map(async ({payload, startLine}) => {
+        const name: string = payload.filePath;
         let id, content;
         try {
           [id, content] = await this.loadfile(name, from);
         } catch {
-          const lineNumber =
-            input.split("\n").findIndex((line) => line.includes(name)) + 1;
-
-          return `<!-- File ${name} not found. Is included by ${from}:${lineNumber} -->`;
-          // throw new Error(
-          //   `File ${name} not found. Is included by ${from}:${lineNumber}.`
-          // );
+          return `<!-- File ${name} not found. Is included by ${from}:${startLine} -->`;
         }
         if (!id || !content) return `<!-- Empty content: ${name} -->`;
         if (alreadyIncluded.has(id)) {
@@ -48,6 +48,9 @@ export class CompileArgdown {
         return `<!-- Start: ${id} -->\n${await this.compile(content, id, alreadyIncluded)}\n<!-- End: ${id} -->`;
       })
     );
-    return input.replace(regex, () => loads.shift() || "");
+    loads.forEach((load, i) => {
+      input = input.replace(includes[i].image, load);
+    });
+    return input;
   }
 }

--- a/packages/argdown-language-server/src/ConnectionHandlers.common.ts
+++ b/packages/argdown-language-server/src/ConnectionHandlers.common.ts
@@ -96,10 +96,14 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
     this.documents.all().forEach((x) => this.validateTextDocument(x));
   }
 
-  protected onRenameRequest({ newName, position, textDocument }: RenameParams) {
+  protected async onRenameRequest({
+    newName,
+    position,
+    textDocument
+  }: RenameParams) {
     const doc = this.getDocument(textDocument.uri);
     if (!doc) return null;
-    const response = this.processDocForProviders(doc);
+    const response = await this.processDocForProviders(doc);
     if (!response) return null;
     return provideRenameWorkspaceEdit(
       response,
@@ -109,18 +113,18 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
     );
   }
 
-  protected handleHover({
+  protected async handleHover({
     textDocument,
     position
   }: TextDocumentPositionParams) {
-    const response = this.processDocForProviders(textDocument);
+    const response = await this.processDocForProviders(textDocument);
     if (!response) return null;
     return provideHover(response, position);
   }
-  protected onCompletion({
+  protected async onCompletion({
     textDocument,
     position
-  }: TextDocumentPositionParams): CompletionItem[] | Promise<CompletionItem[]> {
+  }: TextDocumentPositionParams): Promise<CompletionItem[]> {
     const doc = this.getDocument(textDocument.uri);
     if (!doc) return null;
     const txt = doc.getText();
@@ -140,47 +144,47 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
         input = txt.slice(0, offset - 1) + txtAfter;
       }
     }
-    const response = this.processTextForProviders(input);
+    const response = await this.processDocForProviders(textDocument);
     if (!response) return null;
     return provideCompletion(response, char, position, txt, offset);
   }
 
-  protected onDocumentHighlight({
+  protected async onDocumentHighlight({
     textDocument,
     position
   }: TextDocumentPositionParams) {
-    const response = this.processDocForProviders(textDocument);
+    const response = await this.processDocForProviders(textDocument);
     if (!response) return null;
     return provideReferences(response, textDocument.uri, position).map(
       (l: Location) => DocumentHighlight.create(l.range, 1)
     );
   }
 
-  protected onReferences({ context, position, textDocument }: ReferenceParams) {
-    const response = this.processDocForProviders(textDocument);
+  protected async onReferences({
+    context,
+    position,
+    textDocument
+  }: ReferenceParams) {
+    const response = await this.processDocForProviders(textDocument);
     if (!response) return null;
     return provideReferences(response, textDocument.uri, position, context);
   }
 
-  protected onDefinition({
+  protected async onDefinition({
     textDocument,
     position
   }: TextDocumentPositionParams) {
-    const response = this.processDocForProviders(textDocument);
+    const response = await this.processDocForProviders(textDocument);
     if (!response) return null;
     return provideDefinitions(response, textDocument.uri, position);
   }
 
-  protected onDocumentSymbol(params: DocumentSymbolParams) {
-    const doc = this.getDocument(params.textDocument.uri);
-    if (!doc) return null;
-    return this.getDocumentSymbols(doc.getText());
+  protected onDocumentSymbol({ textDocument }: DocumentSymbolParams) {
+    return this.getDocumentSymbols(textDocument);
   }
 
-  protected onFoldingRanges(params: FoldingRangeParams) {
-    const doc = this.getDocument(params.textDocument.uri);
-    if (!doc) return null;
-    return this.getFoldingRanges(doc.getText());
+  protected onFoldingRanges({ textDocument }: FoldingRangeParams) {
+    return this.getFoldingRanges(textDocument);
   }
 
   private addCapabilities({

--- a/packages/argdown-language-server/src/ConnectionHandlers.common.ts
+++ b/packages/argdown-language-server/src/ConnectionHandlers.common.ts
@@ -38,7 +38,6 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
 
   constructor() {
     super();
-    this.initializeDocumentSettings();
   }
 
   protected onInitialize(params: InitializeParams): InitializeResult {
@@ -212,7 +211,7 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
       return uri1.length - uri2.length;
     });
   }
-  private initializeDocumentSettings() {
+  protected initializeDocumentSettings() {
     this.documents.onDidClose((e) => {
       this.documentSettings.delete(e.document.uri);
     });

--- a/packages/argdown-language-server/src/ConnectionHandlers.common.ts
+++ b/packages/argdown-language-server/src/ConnectionHandlers.common.ts
@@ -53,7 +53,7 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
         hoverProvider: true,
         renameProvider: true,
         completionProvider: {
-          triggerCharacters: ["[", "<", ":", "#", "@", "."]
+          triggerCharacters: ["[", "<", ":", "#", "@"]
         }
       }
     };
@@ -120,7 +120,7 @@ export abstract class ConnectionHandlers extends ArgdownEngine {
   protected onCompletion({
     textDocument,
     position
-  }: TextDocumentPositionParams): CompletionItem[] {
+  }: TextDocumentPositionParams): CompletionItem[] | Promise<CompletionItem[]> {
     const doc = this.getDocument(textDocument.uri);
     if (!doc) return null;
     const txt = doc.getText();

--- a/packages/argdown-language-server/src/ConnectionHandlers.common.ts
+++ b/packages/argdown-language-server/src/ConnectionHandlers.common.ts
@@ -1,0 +1,223 @@
+import { sep } from "path";
+import {
+  CompletionItem,
+  DidChangeConfigurationNotification,
+  DocumentHighlight,
+  DocumentSymbolParams,
+  FoldingRangeParams,
+  InitializeParams,
+  InitializeResult,
+  Location,
+  ReferenceParams,
+  RenameParams,
+  TextDocument,
+  TextDocumentPositionParams,
+  TextDocuments,
+  TextDocumentSyncKind,
+  WorkspaceFolder
+} from "vscode-languageserver";
+import { ArgdownEngine } from "./ArgdownEngine.common";
+import {
+  provideCompletion,
+  provideDefinitions,
+  provideHover,
+  provideReferences,
+  provideRenameWorkspaceEdit
+} from "./providers";
+
+const ONLY_WHITESPACE_PATTERN = /^\s*$/;
+
+export abstract class ConnectionHandlers extends ArgdownEngine {
+  private hasWorkspaceFolderCapability = false;
+  private hasConfigurationCapability = false;
+  private workspaceFolders: WorkspaceFolder[] = [];
+
+  private pathSeperator = sep;
+
+  protected abstract documents: TextDocuments<TextDocument>;
+
+  constructor() {
+    super();
+    this.initializeDocumentSettings();
+  }
+
+  protected onInitialize(params: InitializeParams): InitializeResult {
+    this.addCapabilities(params);
+    return {
+      capabilities: {
+        textDocumentSync: TextDocumentSyncKind.Full,
+        documentSymbolProvider: true,
+        foldingRangeProvider: true,
+        definitionProvider: true,
+        referencesProvider: true,
+        documentHighlightProvider: true,
+        hoverProvider: true,
+        renameProvider: true,
+        completionProvider: {
+          triggerCharacters: ["[", "<", ":", "#", "@", "."]
+        }
+      }
+    };
+  }
+  protected handleInitialized() {
+    this.connection.console.log("Argdown language server initialized.");
+    if (this.hasConfigurationCapability) {
+      void this.connection.client.register(
+        DidChangeConfigurationNotification.type,
+        undefined
+      );
+    }
+
+    if (this.hasWorkspaceFolderCapability) {
+      this.connection.workspace.onDidChangeWorkspaceFolders((event) => {
+        // Removed folders.
+        for (const workspaceFolder of event.removed) {
+          const index = this.workspaceFolders.findIndex(
+            (folder) => folder.uri === workspaceFolder.uri
+          );
+          if (index !== -1) {
+            this.workspaceFolders.splice(index, 1);
+          }
+        }
+        // Added folders.
+        for (const workspaceFolder of event.added) {
+          this.workspaceFolders.push(workspaceFolder);
+        }
+
+        this.sortWorkspaceFolders();
+      });
+    }
+  }
+
+  protected handleDidChangeConfiguration() {
+    if (this.hasConfigurationCapability) {
+      // Reset all cached document settings
+      this.documentSettings.clear();
+    }
+    this.documents.all().forEach((x) => this.validateTextDocument(x));
+  }
+
+  protected onRenameRequest({ newName, position, textDocument }: RenameParams) {
+    const doc = this.getDocument(textDocument.uri);
+    if (!doc) return null;
+    const response = this.processDocForProviders(doc);
+    if (!response) return null;
+    return provideRenameWorkspaceEdit(
+      response,
+      newName,
+      position,
+      textDocument
+    );
+  }
+
+  protected handleHover({
+    textDocument,
+    position
+  }: TextDocumentPositionParams) {
+    const response = this.processDocForProviders(textDocument);
+    if (!response) return null;
+    return provideHover(response, position);
+  }
+  protected onCompletion({
+    textDocument,
+    position
+  }: TextDocumentPositionParams): CompletionItem[] {
+    const doc = this.getDocument(textDocument.uri);
+    if (!doc) return null;
+    const txt = doc.getText();
+    const offset = doc.offsetAt(position);
+    const char = txt.charAt(offset - 1);
+
+    /**
+     * --- Dirty Hack: ---
+     * We have to check if we are at the end of the document and if char equals ':'.
+     * In this case the parser won't produce an ast, but only return a parser error.
+     * To avoid this, we have to remove the ':' from the parsed text.
+     **/
+    let input = txt;
+    if (char === ":") {
+      const txtAfter = txt.slice(offset);
+      if (ONLY_WHITESPACE_PATTERN.test(txtAfter)) {
+        input = txt.slice(0, offset - 1) + txtAfter;
+      }
+    }
+    const response = this.processTextForProviders(input);
+    if (!response) return null;
+    return provideCompletion(response, char, position, txt, offset);
+  }
+
+  protected onDocumentHighlight({
+    textDocument,
+    position
+  }: TextDocumentPositionParams) {
+    const response = this.processDocForProviders(textDocument);
+    if (!response) return null;
+    return provideReferences(response, textDocument.uri, position).map(
+      (l: Location) => DocumentHighlight.create(l.range, 1)
+    );
+  }
+
+  protected onReferences({ context, position, textDocument }: ReferenceParams) {
+    const response = this.processDocForProviders(textDocument);
+    if (!response) return null;
+    return provideReferences(response, textDocument.uri, position, context);
+  }
+
+  protected onDefinition({
+    textDocument,
+    position
+  }: TextDocumentPositionParams) {
+    const response = this.processDocForProviders(textDocument);
+    if (!response) return null;
+    return provideDefinitions(response, textDocument.uri, position);
+  }
+
+  protected onDocumentSymbol(params: DocumentSymbolParams) {
+    const doc = this.getDocument(params.textDocument.uri);
+    if (!doc) return null;
+    return this.getDocumentSymbols(doc.getText());
+  }
+
+  protected onFoldingRanges(params: FoldingRangeParams) {
+    const doc = this.getDocument(params.textDocument.uri);
+    if (!doc) return null;
+    return this.getFoldingRanges(doc.getText());
+  }
+
+  private addCapabilities({
+    capabilities: { workspace },
+    workspaceFolders
+  }: InitializeParams) {
+    this.hasWorkspaceFolderCapability = workspace?.workspaceFolders ?? false;
+    this.hasConfigurationCapability = workspace?.configuration ?? false;
+    if (workspaceFolders) {
+      this.workspaceFolders = workspaceFolders;
+      this.sortWorkspaceFolders();
+    }
+  }
+
+  private sortWorkspaceFolders() {
+    if (!this.workspaceFolders) return;
+    this.workspaceFolders.sort((folder1, folder2) => {
+      let uri1 = folder1.uri.toString();
+      let uri2 = folder2.uri.toString();
+
+      if (!uri1.endsWith("/")) {
+        uri1 += this.pathSeperator;
+      }
+
+      if (uri2.endsWith("/")) {
+        uri2 += this.pathSeperator;
+      }
+      return uri1.length - uri2.length;
+    });
+  }
+  private initializeDocumentSettings() {
+    this.documents.onDidClose((e) => {
+      this.documentSettings.delete(e.document.uri);
+    });
+    this.documents.onDidChangeContent((change) => {
+      this.validateTextDocument(change.document);
+    });
+  }
+}

--- a/packages/argdown-language-server/src/providers/CompilePlugin.ts
+++ b/packages/argdown-language-server/src/providers/CompilePlugin.ts
@@ -1,0 +1,80 @@
+import {
+  ArgdownPluginError,
+  type IArgdownPlugin,
+  type IRequestHandler
+} from "@argdown/core";
+
+export interface ICompileSettings {
+  regEx?: RegExp;
+}
+declare module "@argdown/core" {
+  interface IArgdownRequest {
+    compile?: ICompileSettings;
+    inputPath?: string;
+  }
+}
+
+export class CompilePlugin implements IArgdownPlugin {
+  /**
+   * Loads a file from the given path, relative to the `from` path.
+   * @param path The relative or absolute path of the file to load.
+   * @param from The absolute path of the file that is including this file.
+   * @returns A tuple containing the unique file id (e.g. absolute path of the file) and content.
+   */
+  private loadfile: (path: string, from: string) => [string, string];
+  /**
+   *
+   * @param loadfile see {@link CompilePlugin.loadfile}
+   */
+  constructor(loadfile: (path: string, from: string) => [string, string]) {
+    this.loadfile = loadfile;
+  }
+  name = "CompilePlugin";
+  run: IRequestHandler = (request) => {
+    const { input, inputPath } = request;
+    if (!input) {
+      throw new ArgdownPluginError(
+        this.name,
+        "missing-input-request-field",
+        "Missing input."
+      );
+    }
+    if (!inputPath) {
+      throw new ArgdownPluginError(
+        this.name,
+        "missing-input-path-request-field",
+        "Missing input Path."
+      );
+    }
+    request.input = this.compile(input, inputPath);
+  };
+
+  private alreadyIncluded: Set<string> = new Set();
+
+  // Recursively compiles the input string, replacing @include directives with the contents of the included files. Depth-first, not-parallel.
+  private compile(input: string, from: string): string {
+    const regex: RegExp = /@include\(([^)]+)\)/g;
+    if (!input.match(regex)) return input;
+
+    return input.replace(regex, (_, name) => {
+      let id, content;
+      try {
+        [id, content] = this.loadfile(name, from);
+      } catch {
+        const lineNumber =
+          input.split("\n").findIndex((line) => line.includes(name)) + 1;
+        throw new ArgdownPluginError(
+          this.name,
+          "file-not-found",
+          `File ${name} not found. Is included by ${from}:${lineNumber}.`
+        );
+      }
+      if (!id || !content) return `<!-- Empty content: ${name} -->`;
+      if (this.alreadyIncluded.has(id)) {
+        return `<!-- Already included: ${id} -->`;
+      }
+      this.alreadyIncluded.add(id);
+      return `<!-- Start: ${id} -->\n${this.compile(content, id)}\n<!-- End: ${id} -->`;
+    });
+  }
+}

--- a/packages/argdown-language-server/src/providers/DocumentSymbolPlugin.ts
+++ b/packages/argdown-language-server/src/providers/DocumentSymbolPlugin.ts
@@ -18,7 +18,6 @@ import {
 declare module "@argdown/core" {
   interface IArgdownResponse {
     documentSymbols?: DocumentSymbol[];
-    inputUri?: string;
   }
 }
 

--- a/packages/argdown-language-server/src/providers/provideCompletion.ts
+++ b/packages/argdown-language-server/src/providers/provideCompletion.ts
@@ -26,6 +26,16 @@ export const provideCompletion = (
   );
 
   switch (char) {
+    case "@":
+      return [
+        {
+          ...CompletionItem.create("@include()"),
+          kind: CompletionItemKind.Keyword,
+          detail: "Include an external Argdown file",
+          insertText: "include($1)",
+          insertTextFormat: 2
+        }
+      ];
     case "[":
       return Object.keys(response.statements).map((k: string) => {
         const eqClass = response.statements[k];

--- a/packages/argdown-language-server/src/providers/provideCompletion.ts
+++ b/packages/argdown-language-server/src/providers/provideCompletion.ts
@@ -1,3 +1,4 @@
+import { IArgdownResponse, IArgument, IEquivalenceClass } from "@argdown/core";
 import {
   CompletionItem,
   CompletionItemKind,
@@ -5,94 +6,92 @@ import {
   Range,
   TextEdit
 } from "vscode-languageserver";
-import { IArgument, IEquivalenceClass, IArgdownResponse } from "@argdown/core";
 const statementPattern = /\[([^[]+?)\]$/;
 const argumentPattern = /<([^<]+?)>$/;
+
 export const provideCompletion = (
   response: IArgdownResponse,
   char: string,
   position: Position,
   text: string,
   offset: number
-) => {
+): CompletionItem[] => {
+  if (!response.statements || !response.arguments) return [];
+
   const range = Range.create(
     position.line,
     position.character - 1,
     position.line,
     position.character + 1
   );
-  if (!response.statements || !response.arguments) {
-    return [];
-  }
-  if (char === "[") {
-    return Object.keys(response.statements).map((k: any) => {
-      const eqClass = response.statements[k];
-      const title = eqClass.title;
-      const item = CompletionItem.create(`[${title}]`);
-      item.textEdit = TextEdit.replace(range, `[${title}]`);
-      item.kind = CompletionItemKind.Variable;
-      item.detail = IEquivalenceClass.getCanonicalMemberText(eqClass);
-      return item;
-    });
-  } else if (char === "<") {
-    return Object.keys(response.arguments).map((k: any) => {
-      const argument = response.arguments[k];
-      const title = argument.title;
-      const item = CompletionItem.create(`<${title}>`);
-      item.textEdit = TextEdit.replace(range, `<${title}>`);
-      item.kind = CompletionItemKind.Variable;
-      const desc = IArgument.getCanonicalMemberText(argument);
-      if (desc) {
-        item.detail = desc;
-      }
-      return item;
-    });
-  } else if (char === ":") {
-    const textBefore = text.slice(0, offset - 1);
-    const statementMatch = textBefore.match(statementPattern);
-    if (statementMatch && statementMatch.length > 1) {
-      const title = statementMatch[1];
-      const eqClass = response.statements[title];
-      if (!eqClass.members) {
-        return [];
-      }
-      return eqClass.members
-        .filter((member) => !member.isReference)
-        .map((member) => {
-          const item = CompletionItem.create(member.text);
-          item.kind = CompletionItemKind.Value;
-          item.detail = `[${title}]: ${member.text}`;
-          item.insertText = ` ${member.text}
+
+  switch (char) {
+    case "[":
+      return Object.keys(response.statements).map((k: string) => {
+        const eqClass = response.statements[k];
+        const title = eqClass.title;
+        return {
+          ...CompletionItem.create(`[${title}]`),
+          textEdit: TextEdit.replace(range, `[${title}]`),
+          kind: CompletionItemKind.Variable,
+          detail: IEquivalenceClass.getCanonicalMemberText(eqClass)
+        };
+      });
+    case "<":
+      return Object.keys(response.arguments).map((k: string) => {
+        const arg = response.arguments[k];
+        const title = arg.title;
+        return {
+          ...CompletionItem.create(`<${title}>`),
+          textEdit: TextEdit.replace(range, `<${title}>`),
+          kind: CompletionItemKind.Variable,
+          detail: IArgument.getCanonicalMemberText(arg)
+        };
+      });
+    case "#":
+      return Object.keys(response.tags ?? []).map((t: string) => ({
+        ...CompletionItem.create(`#(${t})`),
+        insertText: `(${t})`,
+        kind: CompletionItemKind.Keyword
+      }));
+    case ":": {
+      const textBefore = text.slice(0, offset - 1);
+      const statementMatch = textBefore.match(statementPattern);
+      if (statementMatch.length > 1) {
+        const title = statementMatch[1];
+        const eqClass = response.statements[title];
+        if (!eqClass.members) return [];
+        return eqClass.members
+          .filter((member) => !member.isReference)
+          .map((member) => {
+            const item = CompletionItem.create(member.text);
+            item.kind = CompletionItemKind.Value;
+            item.detail = `[${title}]: ${member.text}`;
+            item.insertText = ` ${member.text}
 `;
-          return item;
-        });
-    } else {
+            return item;
+          });
+      }
       const argumentMatch = textBefore.match(argumentPattern);
-      if (argumentMatch && argumentMatch.length > 1) {
+      if (argumentMatch.length > 1) {
         const title = argumentMatch[1];
         const argument = response.arguments[title];
-        if (argument.members) {
-          return argument.members
-            .filter((member) => !member.isReference)
-            .map((member) => {
-              const item = CompletionItem.create(member.text);
-              item.kind = CompletionItemKind.Value;
-              item.detail = `<${title}>: ${member.text}`;
-              item.insertText = ` ${member.text}
+        if (!argument.members) return [];
+        return argument.members
+          .filter((member) => !member.isReference)
+          .map((member) => {
+            const item = CompletionItem.create(member.text);
+            item.kind = CompletionItemKind.Value;
+            item.detail = `<${title}>: ${member.text}`;
+            item.insertText = ` ${member.text}
 `;
-              item.kind = CompletionItemKind.Value;
-              return item;
-            });
-        }
+            item.kind = CompletionItemKind.Value;
+            return item;
+          });
       }
     }
-  } else if (char === "#" && response.tags) {
-    return Object.keys(response.tags).map((t: any) => {
-      const item = CompletionItem.create(`#(${t})`);
-      item.insertText = `(${t})`;
-      item.kind = CompletionItemKind.Keyword;
-      return item;
-    });
+
+    default:
+      return [];
   }
-  return [];
 };

--- a/packages/argdown-language-server/src/server.common.ts
+++ b/packages/argdown-language-server/src/server.common.ts
@@ -73,7 +73,7 @@ export class Server {
           hoverProvider: true,
           renameProvider: true,
           completionProvider: {
-            triggerCharacters: ["[", "<", ":", "#"]
+            triggerCharacters: ["[", "<", ":", "#", "@"]
           }
         }
       };

--- a/packages/argdown-language-server/src/server.common.ts
+++ b/packages/argdown-language-server/src/server.common.ts
@@ -1,332 +1,35 @@
-import { argdown, IArgdownRequest, IArgdownResponse } from "@argdown/core";
-import { sep } from "path";
-import type {
-  Connection,
-  DocumentSymbolParams,
-  FoldingRangeParams,
-  InitializeParams,
-  Location,
-  ReferenceParams,
-  RenameParams,
-  TextDocumentIdentifier,
-  TextDocumentPositionParams,
-  WorkspaceFolder
-} from "vscode-languageserver";
-import {
-  Diagnostic,
-  DiagnosticSeverity,
-  DidChangeConfigurationNotification,
-  DocumentHighlight,
-  Range,
-  TextDocuments,
-  TextDocumentSyncKind
-} from "vscode-languageserver";
+import { Connection, DocumentUri, TextDocuments } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { IArgdownSettings } from "./IArgdownSettings";
-import {
-  provideCompletion,
-  provideDefinitions,
-  provideHover,
-  provideReferences,
-  provideRenameWorkspaceEdit
-} from "./providers";
-import { DocumentSymbolPlugin } from "./providers/DocumentSymbolPlugin";
-import { FoldingRangesPlugin } from "./providers/FoldingRangesPlugin";
+import { ConnectionHandlers } from "./ConnectionHandlers.common";
 
-export class Server {
-  private static ONLY_WHITESPACE_PATTERN = /^\s*$/;
-
-  private argdown = argdown;
-  private loglevel = "verbose";
-  private hasWorkspaceFolderCapability = false;
-  private hasConfigurationCapability = false;
-  private workspaceFolders: WorkspaceFolder[] = [];
-  private documents: TextDocuments<TextDocument> = new TextDocuments(
+export class Server extends ConnectionHandlers {
+  protected documents: TextDocuments<TextDocument> = new TextDocuments(
     TextDocument
   );
-  private documentSettings: Map<string, Thenable<IArgdownSettings>> = new Map();
-
-  private pathSeperator = sep;
-
-  constructor(private connection: Connection) {}
-
+  protected getDocument(uri: DocumentUri): TextDocument {
+    return this.documents.get(uri);
+  }
+  constructor(protected connection: Connection) {
+    super();
+  }
   public init() {
-    this.argdown.addPlugin(new DocumentSymbolPlugin(), "add-document-symbols");
-    this.argdown.addPlugin(new FoldingRangesPlugin(), "add-folding-ranges");
-    this.addLogger();
-    this.initializeDocumentSettings();
     this.initializeConnection();
     this.documents.listen(this.connection);
     this.connection.listen();
   }
   private initializeConnection() {
-    this.connection.onInitialize((params: InitializeParams) => {
-      this.addCapabilities(params);
-      return {
-        capabilities: {
-          textDocumentSync: TextDocumentSyncKind.Full,
-          documentSymbolProvider: true,
-          foldingRangeProvider: true,
-          definitionProvider: true,
-          referencesProvider: true,
-          documentHighlightProvider: true,
-          hoverProvider: true,
-          renameProvider: true,
-          completionProvider: {
-            triggerCharacters: ["[", "<", ":", "#", "@"]
-          }
-        }
-      };
-    });
-    this.connection.onInitialized(() => {
-      this.connection.console.log("Argdown language server initialized.");
-      if (this.hasConfigurationCapability) {
-        void this.connection.client.register(
-          DidChangeConfigurationNotification.type,
-          undefined
-        );
-      }
-
-      if (this.hasWorkspaceFolderCapability) {
-        this.connection.workspace.onDidChangeWorkspaceFolders((event) => {
-          // Removed folders.
-          for (const workspaceFolder of event.removed) {
-            const index = this.workspaceFolders.findIndex(
-              (folder) => folder.uri === workspaceFolder.uri
-            );
-            if (index !== -1) {
-              this.workspaceFolders.splice(index, 1);
-            }
-          }
-          // Added folders.
-          for (const workspaceFolder of event.added) {
-            this.workspaceFolders.push(workspaceFolder);
-          }
-
-          this.sortWorkspaceFolders();
-        });
-      }
-    });
-    this.connection.onDidChangeConfiguration(() => {
-      if (this.hasConfigurationCapability) {
-        // Reset all cached document settings
-        this.documentSettings.clear();
-      }
-      this.documents.all().forEach((x) => this.validateTextDocument(x));
-    });
-    this.connection.onRenameRequest(
-      ({ newName, position, textDocument }: RenameParams) => {
-        const doc = this.documents.get(textDocument.uri);
-        if (!doc) return null;
-        let response: IArgdownResponse | null = null;
-        response = this.processDocForProviders(doc);
-        if (!response) return null;
-        return provideRenameWorkspaceEdit(
-          response,
-          newName,
-          position,
-          textDocument
-        );
-      }
+    this.connection.onInitialize(this.onInitialize.bind(this));
+    this.connection.onInitialized(this.handleInitialized.bind(this));
+    this.connection.onDidChangeConfiguration(
+      this.handleDidChangeConfiguration.bind(this)
     );
-    this.connection.onHover(
-      ({ textDocument, position }: TextDocumentPositionParams) => {
-        const response = this.processDocForProviders(textDocument);
-        if (!response) return null;
-        return provideHover(response, position);
-      }
-    );
-    this.connection.onCompletion(
-      ({ textDocument, position }: TextDocumentPositionParams) => {
-        const doc = this.documents.get(textDocument.uri);
-        if (!doc) return null;
-        const txt = doc.getText();
-        const offset = doc.offsetAt(position);
-        const char = txt.charAt(offset - 1);
-        /**
-         * --- Dirty Hack: ---
-         * We have to check if we are at the end of the document and if char equals ':'.
-         * In this case the parser won't produce an ast, but only return a parser error.
-         * To avoid this, we have to remove the ':' from the parsed text.
-         **/
-        let input = txt;
-        if (char === ":") {
-          const txtAfter = txt.slice(offset);
-          if (Server.ONLY_WHITESPACE_PATTERN.test(txtAfter)) {
-            input = txt.slice(0, offset - 1) + txtAfter;
-          }
-        }
-        const response = this.processTextForProviders(input);
-        if (!response) return null;
-        return provideCompletion(response, char, position, txt, offset);
-      }
-    );
-    this.connection.onDocumentHighlight(
-      ({ textDocument, position }: TextDocumentPositionParams) => {
-        const response = this.processDocForProviders(textDocument);
-        if (!response) return null;
-        return provideReferences(response, textDocument.uri, position).map(
-          (l: Location) => DocumentHighlight.create(l.range, 1)
-        );
-      }
-    );
-    this.connection.onReferences(
-      ({ context, position, textDocument }: ReferenceParams) => {
-        const response = this.processDocForProviders(textDocument);
-        if (!response) return null;
-        return provideReferences(response, textDocument.uri, position, context);
-      }
-    );
-    this.connection.onDefinition(
-      ({ textDocument, position }: TextDocumentPositionParams) => {
-        const response = this.processDocForProviders(textDocument);
-        if (!response) return null;
-        return provideDefinitions(response, textDocument.uri, position);
-      }
-    );
-    this.connection.onDocumentSymbol((params: DocumentSymbolParams) => {
-      const doc = this.documents.get(params.textDocument.uri);
-      if (!doc) return null;
-      const request: IArgdownRequest & { inputUri: string } = {
-        input: doc.getText(),
-        process: ["parse-input", "build-model", "add-document-symbols"],
-        inputUri: params.textDocument.uri,
-        parser: {
-          throwExceptions: true
-        },
-        throwExceptions: true
-      };
-      try {
-        return this.argdown.run(request).documentSymbols;
-      } catch {
-        return null;
-      }
-    });
-    this.connection.onFoldingRanges((params: FoldingRangeParams) => {
-      const doc = this.documents.get(params.textDocument.uri);
-      if (!doc) return null;
-      const request: IArgdownRequest & { inputUri: string } = {
-        input: doc.getText(),
-        process: ["parse-input", "build-model", "add-folding-ranges"],
-        inputUri: params.textDocument.uri,
-        parser: {
-          throwExceptions: true
-        },
-        throwExceptions: true
-      };
-      try {
-        return this.argdown.run(request).foldingRanges;
-      } catch {
-        return null;
-      }
-    });
-  }
-
-  private initializeDocumentSettings() {
-    this.documents.onDidClose((e) => {
-      this.documentSettings.delete(e.document.uri);
-    });
-    this.documents.onDidChangeContent((change) => {
-      this.validateTextDocument(change.document);
-    });
-  }
-  private addCapabilities({
-    capabilities: { workspace },
-    workspaceFolders
-  }: InitializeParams) {
-    this.hasWorkspaceFolderCapability = workspace?.workspaceFolders ?? false;
-    this.hasConfigurationCapability = workspace?.configuration ?? false;
-    if (workspaceFolders) {
-      this.workspaceFolders = workspaceFolders;
-      this.sortWorkspaceFolders();
-    }
-  }
-  private addLogger() {
-    this.argdown.logger = {
-      setLevel: (level: string) => {
-        this.loglevel = level;
-      },
-      log: (_level: string, message: string) => {
-        if (this.loglevel === "verbose") {
-          this.connection.console.log(message);
-        }
-      }
-    };
-  }
-  private sortWorkspaceFolders() {
-    if (!this.workspaceFolders) return;
-    this.workspaceFolders.sort((folder1, folder2) => {
-      let uri1 = folder1.uri.toString();
-      let uri2 = folder2.uri.toString();
-
-      if (!uri1.endsWith("/")) {
-        uri1 += this.pathSeperator;
-      }
-
-      if (uri2.endsWith("/")) {
-        uri2 += this.pathSeperator;
-      }
-
-      return uri1.length - uri2.length;
-    });
-  }
-  private validateTextDocument(textDocument: TextDocument): void {
-    const text = textDocument.getText();
-    const result = this.argdown.run({
-      process: ["parse-input", "build-model"],
-      input: text
-    });
-
-    const diagnostics: Diagnostic[] =
-      result.parserErrors
-        ?.map(
-          ({
-            message,
-            token: { startLine, startColumn, endLine, endColumn }
-          }) => {
-            if (!startLine || !startColumn || !endLine || !endColumn) return; // Should never happen
-            const start = {
-              line: startLine - 1,
-              character: startColumn - 1
-            };
-            const end = {
-              line: endLine - 1,
-              character: endColumn
-            }; //end character is zero based, exclusive
-            const range = Range.create(start, end);
-            const severity = DiagnosticSeverity.Error;
-            return Diagnostic.create(range, message, severity, "argdown");
-          }
-        )
-        .filter((x): x is Diagnostic => !!x) ?? [];
-
-    // Send the computed diagnostics to VSCode.
-    void this.connection.sendDiagnostics({
-      uri: textDocument.uri,
-      diagnostics
-    });
-  }
-  private processTextForProviders(text: string) {
-    const request: IArgdownRequest = {
-      input: text,
-      process: ["parse-input", "build-model"],
-      throwExceptions: true,
-      parser: {
-        throwExceptions: true
-      }
-    };
-    try {
-      return this.argdown.run(request);
-    } catch {
-      return null;
-    }
-  }
-  private processDocForProviders(textDocument: TextDocumentIdentifier) {
-    const doc = this.documents.get(textDocument.uri);
-    if (doc) {
-      const text = doc.getText();
-      return this.processTextForProviders(text);
-    }
-    return null;
+    this.connection.onRenameRequest(this.onRenameRequest.bind(this));
+    this.connection.onHover(this.handleHover.bind(this));
+    this.connection.onCompletion(this.onCompletion.bind(this));
+    this.connection.onDocumentHighlight(this.onDocumentHighlight.bind(this));
+    this.connection.onReferences(this.onReferences.bind(this));
+    this.connection.onDefinition(this.onDefinition.bind(this));
+    this.connection.onDocumentSymbol(this.onDocumentSymbol.bind(this));
+    this.connection.onFoldingRanges(this.onFoldingRanges.bind(this));
   }
 }

--- a/packages/argdown-language-server/src/server.common.ts
+++ b/packages/argdown-language-server/src/server.common.ts
@@ -13,6 +13,7 @@ export class Server extends ConnectionHandlers {
     super();
   }
   public init() {
+    this.initializeDocumentSettings();
     this.initializeConnection();
     this.documents.listen(this.connection);
     this.connection.listen();

--- a/packages/argdown-language-server/src/server.node.ts
+++ b/packages/argdown-language-server/src/server.node.ts
@@ -5,16 +5,17 @@ import { fileURLToPath } from "node:url";
 import {
   CompletionItem,
   CompletionItemKind,
+  CompletionParams,
   createConnection,
-  Position,
   ProposedFeatures,
-  TextDocumentIdentifier
+  TextDocumentIdentifier,
+  Range,
+  TextEdit
 } from "vscode-languageserver/node";
 import { CompileArgdown } from "./CompileArgdown";
 import { Server } from "./server.common";
 import { getFilePaths } from "./utils/fs.node";
 
-const incl: RegExp = /@include\(([^)]+)\)/g;
 class ServerNode extends Server {
   private argdownCompiler = new CompileArgdown(
     async (path: string, from: string) => {
@@ -27,42 +28,50 @@ class ServerNode extends Server {
   protected async onCompletion({
     textDocument,
     position
-  }): Promise<CompletionItem[]> {
+  }: CompletionParams): Promise<CompletionItem[]> {
     const doc = this.documents.get(textDocument.uri);
     if (!doc) return null;
-    const line = doc.getText({
-      start: Position.create(position.line, 0),
-      end: Position.create(position.line, Number.MAX_SAFE_INTEGER)
+    const { includes } = this.argdown.run({
+      process: ["parse-input", "include-positions"],
+      input: doc.getText()
     });
-    const matches = Array.from(line.matchAll(incl));
-    const inclUnderCurser = matches
-      .filter((match) => {
-        const startPos = match.index + match[0].indexOf(match[1]);
-        const endPos = match.index + match[0].length - 1;
-        return startPos <= position.character && position.character <= endPos;
-      })
-      .pop();
+    const currentLine = position.line + 1;
 
-    if (inclUnderCurser) {
-      const [_, fileName] = inclUnderCurser;
-      const thisFile = fileURLToPath(textDocument.uri);
-      const base = join(dirname(thisFile), dirname(fileName));
+    const candidate = includes.filter(({ startLine, endLine, startColumn, endColumn }) => {
+      const inLine = startLine <= currentLine && currentLine <= endLine
+      const inParentesis = startColumn + "@include(".length - 1 <= position.character && position.character <= endColumn - 1;
+      return inLine && inParentesis
+    })
+    if (candidate.length !== 1) return super.onCompletion({ textDocument, position });
 
-      const norm = (s: string) => s.replace(base + "/", "");
+    console.log("We are in a position: ", candidate)
+    const { payload: { filePath }, startLine, endLine, startColumn, endColumn } = candidate[0];
+    if(typeof filePath !== "string") return super.onCompletion({ textDocument, position });
+    const thisFile = fileURLToPath(textDocument.uri);
 
-      const x = await getFilePaths({
-        globPattern: "**/*.argdown",
-        rootPath: base,
-        maxItems: 20
-      });
+    const base = join(dirname(thisFile), dirname(filePath));
 
-      return x.map((file) => ({
-        ...CompletionItem.create(norm(file)),
-        kind: CompletionItemKind.File,
-        insertText: norm(file)
-      }));
-    }
-    return super.onCompletion({ textDocument, position });
+    const norm = (s: string) => s.replace(base + "/", "");
+
+    const x = await getFilePaths({
+      globPattern: "**/*.argdown",
+      rootPath: base,
+      maxItems: 20
+    });
+
+    const range = Range.create(
+      startLine - 1,
+      startColumn + "@include(".length - 1,
+      endLine - 1,
+      endColumn - 1
+    );
+    const repl =  x.map((file) => ({
+      ...CompletionItem.create(norm(file)),
+      kind: CompletionItemKind.File,
+      textEdit: TextEdit.replace(range, norm(file)),
+    }));
+    console.log(range, position, repl)
+    return repl;
   }
   protected async doc2String(textDocument: TextDocumentIdentifier) {
     const input = await super.doc2String(textDocument);
@@ -70,7 +79,6 @@ class ServerNode extends Server {
       input,
       fileURLToPath(textDocument.uri)
     );
-    this.connection.console.log(compiled);
     return compiled;
   }
 }

--- a/packages/argdown-language-server/src/server.node.ts
+++ b/packages/argdown-language-server/src/server.node.ts
@@ -1,8 +1,48 @@
 #!/usr/bin/env node
-import { createConnection, ProposedFeatures } from "vscode-languageserver/node";
+import {
+  CompletionItem,
+  CompletionItemKind,
+  createConnection,
+  ProposedFeatures,
+  TextDocumentPositionParams
+} from "vscode-languageserver/node";
 import { Server } from "./server.common";
+import { URI, Utils } from "vscode-uri";
+
+class ServerNode extends Server {
+  protected onCompletion({
+    textDocument,
+    position
+  }: TextDocumentPositionParams): CompletionItem[] {
+    const doc = this.documents.get(textDocument.uri);
+    if (!doc) return null;
+    const txt = doc.getText();
+    const offset = doc.offsetAt(position);
+    const char = txt.charAt(offset - 1);
+    if (char === ".") {
+      const base = Utils.dirname(URI.parse(textDocument.uri));
+      const files = this.documents.all();
+
+      const norm = (s: string) => s.replace(base.toString(), ".");
+
+      return [
+        {
+          ...CompletionItem.create(norm(textDocument.uri)),
+          kind: CompletionItemKind.File,
+          insertText: norm(textDocument.uri)
+        },
+        ...files.map((file) => ({
+          ...CompletionItem.create("Others: " + norm(file.uri)),
+          kind: CompletionItemKind.File,
+          insertText: norm(file.uri)
+        }))
+      ];
+    }
+    return super.onCompletion({ textDocument, position });
+  }
+}
 
 const connection = createConnection(ProposedFeatures.all);
-const serverNode = new Server(connection);
+const serverNode = new ServerNode(connection);
 
 serverNode.init();

--- a/packages/argdown-language-server/src/server.node.ts
+++ b/packages/argdown-language-server/src/server.node.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   CompletionItem,
@@ -7,17 +8,26 @@ import {
   createConnection,
   Position,
   ProposedFeatures,
-  TextDocumentPositionParams
+  TextDocumentIdentifier
 } from "vscode-languageserver/node";
+import { CompileArgdown } from "./CompileArgdown";
 import { Server } from "./server.common";
 import { getFilePaths } from "./utils/fs.node";
 
 const incl: RegExp = /@include\(([^)]+)\)/g;
 class ServerNode extends Server {
+  private argdownCompiler = new CompileArgdown(
+    async (path: string, from: string) => {
+      const dir = dirname(from);
+      const resolved = resolve(dir, path);
+      const content = await readFile(resolved, "utf8");
+      return [resolved, content];
+    }
+  );
   protected async onCompletion({
     textDocument,
     position
-  }: TextDocumentPositionParams): Promise<CompletionItem[]> {
+  }): Promise<CompletionItem[]> {
     const doc = this.documents.get(textDocument.uri);
     if (!doc) return null;
     const line = doc.getText({
@@ -53,6 +63,15 @@ class ServerNode extends Server {
       }));
     }
     return super.onCompletion({ textDocument, position });
+  }
+  protected async doc2String(textDocument: TextDocumentIdentifier) {
+    const input = await super.doc2String(textDocument);
+    const compiled = await this.argdownCompiler.compile(
+      input,
+      fileURLToPath(textDocument.uri)
+    );
+    this.connection.console.log(compiled);
+    return compiled;
   }
 }
 

--- a/packages/argdown-language-server/src/server.node.ts
+++ b/packages/argdown-language-server/src/server.node.ts
@@ -1,42 +1,56 @@
 #!/usr/bin/env node
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   CompletionItem,
   CompletionItemKind,
   createConnection,
+  Position,
   ProposedFeatures,
   TextDocumentPositionParams
 } from "vscode-languageserver/node";
 import { Server } from "./server.common";
-import { URI, Utils } from "vscode-uri";
+import { getFilePaths } from "./utils/fs.node";
 
+const incl: RegExp = /@include\(([^)]+)\)/g;
 class ServerNode extends Server {
-  protected onCompletion({
+  protected async onCompletion({
     textDocument,
     position
-  }: TextDocumentPositionParams): CompletionItem[] {
+  }: TextDocumentPositionParams): Promise<CompletionItem[]> {
     const doc = this.documents.get(textDocument.uri);
     if (!doc) return null;
-    const txt = doc.getText();
-    const offset = doc.offsetAt(position);
-    const char = txt.charAt(offset - 1);
-    if (char === ".") {
-      const base = Utils.dirname(URI.parse(textDocument.uri));
-      const files = this.documents.all();
+    const line = doc.getText({
+      start: Position.create(position.line, 0),
+      end: Position.create(position.line, Number.MAX_SAFE_INTEGER)
+    });
+    const matches = Array.from(line.matchAll(incl));
+    const inclUnderCurser = matches
+      .filter((match) => {
+        const startPos = match.index + match[0].indexOf(match[1]);
+        const endPos = match.index + match[0].length - 1;
+        return startPos <= position.character && position.character <= endPos;
+      })
+      .pop();
 
-      const norm = (s: string) => s.replace(base.toString(), ".");
+    if (inclUnderCurser) {
+      const [_, fileName] = inclUnderCurser;
+      const thisFile = fileURLToPath(textDocument.uri);
+      const base = join(dirname(thisFile), dirname(fileName));
 
-      return [
-        {
-          ...CompletionItem.create(norm(textDocument.uri)),
-          kind: CompletionItemKind.File,
-          insertText: norm(textDocument.uri)
-        },
-        ...files.map((file) => ({
-          ...CompletionItem.create("Others: " + norm(file.uri)),
-          kind: CompletionItemKind.File,
-          insertText: norm(file.uri)
-        }))
-      ];
+      const norm = (s: string) => s.replace(base + "/", "");
+
+      const x = await getFilePaths({
+        globPattern: "**/*.argdown",
+        rootPath: base,
+        maxItems: 20
+      });
+
+      return x.map((file) => ({
+        ...CompletionItem.create(norm(file)),
+        kind: CompletionItemKind.File,
+        insertText: norm(file)
+      }));
     }
     return super.onCompletion({ textDocument, position });
   }

--- a/packages/argdown-language-server/src/utils/fs.node.ts
+++ b/packages/argdown-language-server/src/utils/fs.node.ts
@@ -29,7 +29,7 @@ export async function getFilePaths({
 
   const stream = fastGlob.stream([globPattern], {
     absolute: true,
-    onlyFiles: true,
+    onlyFiles: false,
     cwd: rootPath,
     followSymbolicLinks: true,
     suppressErrors: true

--- a/packages/argdown-language-server/src/utils/fs.node.ts
+++ b/packages/argdown-language-server/src/utils/fs.node.ts
@@ -1,0 +1,55 @@
+/**
+ * Copied from https://github.com/mads-hartmann/bash-language-server/blob/3218a314d333b96f00cbe28e073a75425083fcbd/server/src/util/fs.ts
+ */
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+
+import * as fastGlob from "fast-glob";
+
+// from https://github.com/sindresorhus/untildify/blob/f85a087418aeaa2beb56fe2684fe3b64fc8c588d/index.js#L11
+export function untildify(pathWithTilde: string): string {
+  const homeDirectory = os.homedir();
+  return homeDirectory
+    ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
+    : pathWithTilde;
+}
+
+export async function getFilePaths({
+  globPattern,
+  rootPath,
+  maxItems
+}: {
+  globPattern: string;
+  rootPath: string;
+  maxItems: number;
+}): Promise<string[]> {
+  if (rootPath.startsWith("file://")) {
+    rootPath = fileURLToPath(rootPath);
+  }
+
+  const stream = fastGlob.stream([globPattern], {
+    absolute: true,
+    onlyFiles: true,
+    cwd: rootPath,
+    followSymbolicLinks: true,
+    suppressErrors: true
+  });
+
+  // NOTE: we use a stream here to not block the event loop
+  // and ensure that we stop reading files if the glob returns
+  // too many files.
+  const files = [];
+  let i = 0;
+  for await (const fileEntry of stream) {
+    if (i >= maxItems) {
+      // NOTE: Close the stream to stop reading files paths.
+      stream.emit("close");
+      break;
+    }
+
+    files.push(fileEntry.toString());
+    i++;
+  }
+
+  return files;
+}

--- a/packages/argdown-language-server/tsconfig.json
+++ b/packages/argdown-language-server/tsconfig.json
@@ -1,4 +1,8 @@
 {
   // Handled by esbuild. Only needed for editor language services
-  "include": ["src", "esbuild"]
+  "include": ["src", "esbuild"],
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "preserve"
+  }
 }

--- a/packages/argdown-vscode/preview/IArgdownPreviewState.ts
+++ b/packages/argdown-vscode/preview/IArgdownPreviewState.ts
@@ -28,6 +28,7 @@ export interface IArgdownPreviewState {
     ];
   };
   html: {
+    html?: string;
     line: number;
     lineCount?: number;
   };

--- a/packages/argdown-vscode/preview/htmlView.ts
+++ b/packages/argdown-vscode/preview/htmlView.ts
@@ -12,6 +12,8 @@ import { ArgdownPreviewStore } from "./state";
 
 declare var acquireVsCodeApi: any;
 
+const htmlContainer = document.getElementById("html-container")!;
+
 var scrollDisabled = true;
 const marker = new ActiveLineMarker();
 const settings = getSettings();
@@ -30,6 +32,8 @@ onceDocumentLoaded(() => {
   if (settings.scrollPreviewWithEditor) {
     setTimeout(() => {
       const initialLine = +store.getState().html.line;
+      const htmlContent = store.getState().html.html;
+      if (htmlContent) htmlContainer.innerHTML = htmlContent;
       if (!isNaN(initialLine)) {
         scrollDisabled = true;
         scrollToRevealSourceLine(initialLine);
@@ -74,6 +78,10 @@ window.addEventListener(
     }
 
     switch (event.data.type) {
+      case "didChangeTextDocument":
+        const htmlContent = event.data.html;
+        if (htmlContent) htmlContainer.innerHTML = htmlContent;
+        break;
       case "onDidChangeTextEditorSelection":
         marker.onDidChangeTextEditorSelection(event.data.line);
         break;

--- a/packages/argdown-vscode/src/ArgdownEngine.ts
+++ b/packages/argdown-vscode/src/ArgdownEngine.ts
@@ -16,7 +16,7 @@ import type { Logger } from "./Logger";
 import type { ArgdownConfiguration } from "./config/ArgdownConfiguration";
 import type { IArgdownConfigLoader } from "./config/IArgdownConfigLoader";
 import { findElementAtPositionPlugin } from "./preview/FindElementAtPositionPlugin";
-import { CompileArgdown } from "./compileArgdown";
+import { CompileArgdown } from "./CompileArgdown";
 import { loadFile } from "./loadfile";
 
 argdown.addPlugin(findElementAtPositionPlugin, "find-element-at-position");

--- a/packages/argdown-vscode/src/ArgdownEngine.ts
+++ b/packages/argdown-vscode/src/ArgdownEngine.ts
@@ -16,10 +16,13 @@ import type { Logger } from "./Logger";
 import type { ArgdownConfiguration } from "./config/ArgdownConfiguration";
 import type { IArgdownConfigLoader } from "./config/IArgdownConfigLoader";
 import { findElementAtPositionPlugin } from "./preview/FindElementAtPositionPlugin";
+import { CompileArgdown } from "./compileArgdown";
+import { loadFile } from "./loadfile";
 
 argdown.addPlugin(findElementAtPositionPlugin, "find-element-at-position");
+// argdown.addPlugin(plugin)
 
-export class ArgdownEngine {
+export class ArgdownEngine extends CompileArgdown {
   public constructor(
     private logger: Logger,
     private configLoader: IArgdownConfigLoader
@@ -35,10 +38,14 @@ export class ArgdownEngine {
         }
       }
     };
+    super(loadFile);
   }
-  public exportHtml(doc: TextDocument, config: ArgdownConfiguration): string {
+  public async exportHtml(
+    doc: TextDocument,
+    config: ArgdownConfiguration
+  ): Promise<string> {
     const argdownConfig = config.argdownConfig || {};
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request: IArgdownRequest = {
       ...argdownConfig,
       input: input,
@@ -292,7 +299,8 @@ export class ArgdownEngine {
     config: ArgdownConfiguration
   ): Promise<{ svg: string; dot: string; request: IArgdownRequest }> {
     const argdownConfig = config.argdownConfig || {};
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
+    this.logger.log("export svg compiled", input);
     const request = {
       ...argdownConfig,
       input: input,

--- a/packages/argdown-vscode/src/ArgdownEngine.ts
+++ b/packages/argdown-vscode/src/ArgdownEngine.ts
@@ -219,9 +219,12 @@ export class ArgdownEngine extends CompileArgdown {
     }
     return null;
   }
-  public getMap(doc: TextDocument, config: ArgdownConfiguration): IMap {
+  public async getMap(
+    doc: TextDocument,
+    config: ArgdownConfiguration
+  ): Promise<IMap> {
     const argdownConfig = config.argdownConfig;
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request = {
       ...argdownConfig,
       input: input,
@@ -240,16 +243,19 @@ export class ArgdownEngine extends CompileArgdown {
     if (!map) throw new Error("No map in response");
     return map;
   }
-  public exportMapJson(
+  public async exportMapJson(
     doc: TextDocument,
     config: ArgdownConfiguration
-  ): string {
-    const map = this.getMap(doc, config);
+  ): Promise<string> {
+    const map = await this.getMap(doc, config);
     return stringifyArgdownData(map);
   }
-  public exportJson(doc: TextDocument, config: ArgdownConfiguration): string {
+  public async exportJson(
+    doc: TextDocument,
+    config: ArgdownConfiguration
+  ): Promise<string> {
     const argdownConfig = config.argdownConfig;
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request = {
       ...argdownConfig,
       input: input,
@@ -268,12 +274,12 @@ export class ArgdownEngine extends CompileArgdown {
     if (!json) throw new Error("No JSON response");
     return json;
   }
-  public exportDot(
+  public async exportDot(
     doc: TextDocument,
     config: ArgdownConfiguration
-  ): { dot: string; request: IArgdownRequest } {
+  ): Promise<{ dot: string; request: IArgdownRequest }> {
     const argdownConfig = config.argdownConfig || {};
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request = {
       ...argdownConfig,
       input: input,
@@ -334,7 +340,7 @@ export class ArgdownEngine extends CompileArgdown {
     config: ArgdownConfiguration
   ): Promise<string> {
     const argdownConfig = config.argdownConfig || {};
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request = {
       ...argdownConfig,
       input: input,
@@ -358,12 +364,12 @@ export class ArgdownEngine extends CompileArgdown {
     if (!webComponent) throw new Error("No web component response");
     return webComponent;
   }
-  public exportGraphML(
+  public async exportGraphML(
     doc: TextDocument,
     config: ArgdownConfiguration
-  ): string {
+  ): Promise<string> {
     const argdownConfig = config.argdownConfig || {};
-    const input = doc.getText();
+    const input = await this.compile(doc.getText(), doc.uri.fsPath);
     const request = {
       ...argdownConfig,
       input: input,

--- a/packages/argdown-vscode/src/CompileArgdown.ts
+++ b/packages/argdown-vscode/src/CompileArgdown.ts
@@ -34,9 +34,11 @@ export class CompileArgdown {
         } catch {
           const lineNumber =
             input.split("\n").findIndex((line) => line.includes(name)) + 1;
-          throw new Error(
-            `File ${name} not found. Is included by ${from}:${lineNumber}.`
-          );
+
+          return `<!-- File ${name} not found. Is included by ${from}:${lineNumber} -->`;
+          // throw new Error(
+          //   `File ${name} not found. Is included by ${from}:${lineNumber}.`
+          // );
         }
         if (!id || !content) return `<!-- Empty content: ${name} -->`;
         if (alreadyIncluded.has(id)) {

--- a/packages/argdown-vscode/src/commands/export/exportDot.ts
+++ b/packages/argdown-vscode/src/commands/export/exportDot.ts
@@ -22,7 +22,7 @@ export class ExportDocumentToDotCommand implements Command {
     if (!uri) throw new Error("No file provided!");
     const config = new ArgdownConfiguration(uri, this.engine);
     const doc: TextDocument = await workspace.openTextDocument(uri);
-    const { dot } = this.engine.exportDot(doc, config);
+    const { dot } = await this.engine.exportDot(doc, config);
     await saveExportedFile(uri, dot, { Dot: ["dot"] }, "dot");
   }
 }

--- a/packages/argdown-vscode/src/commands/export/exportGraphML.ts
+++ b/packages/argdown-vscode/src/commands/export/exportGraphML.ts
@@ -22,7 +22,7 @@ export class ExportDocumentToGraphMLCommand implements Command {
     if (!uri) throw new Error("No file provided!");
     const config = new ArgdownConfiguration(uri, this.engine);
     const doc: TextDocument = await workspace.openTextDocument(uri);
-    const result = this.engine.exportGraphML(doc, config);
+    const result = await this.engine.exportGraphML(doc, config);
     await saveExportedFile(uri, result, { graphml: ["graphml"] }, "graphml");
   }
 }

--- a/packages/argdown-vscode/src/commands/export/exportHtml.ts
+++ b/packages/argdown-vscode/src/commands/export/exportHtml.ts
@@ -22,7 +22,7 @@ export class ExportDocumentToHtmlCommand implements Command {
     if (!uri) throw new Error("No file provided!");
     const config = new ArgdownConfiguration(uri, this.engine);
     const doc: TextDocument = await workspace.openTextDocument(uri);
-    const result = this.engine.exportHtml(doc, config);
+    const result = await this.engine.exportHtml(doc, config);
     await saveExportedFile(uri, result, { HTML: ["html"] }, "html");
   }
 }

--- a/packages/argdown-vscode/src/commands/export/exportJson.ts
+++ b/packages/argdown-vscode/src/commands/export/exportJson.ts
@@ -22,7 +22,7 @@ export class ExportDocumentToJsonCommand implements Command {
     if (!uri) throw new Error("No file provided!");
     const config = new ArgdownConfiguration(uri, this.engine);
     const doc: TextDocument = await workspace.openTextDocument(uri);
-    const result = this.engine.exportJson(doc, config);
+    const result = await this.engine.exportJson(doc, config);
     await saveExportedFile(uri, result, { JSON: ["json"] }, "json");
   }
 }

--- a/packages/argdown-vscode/src/compileArgdown.ts
+++ b/packages/argdown-vscode/src/compileArgdown.ts
@@ -1,0 +1,51 @@
+export class CompileArgdown {
+  /**
+   * Loads a file from the given path, relative to the `from` path.
+   * @param path The relative or absolute path of the file to load.
+   * @param from The absolute path of the file that is including this file.
+   * @returns A tuple containing the unique file id (e.g. absolute path of the file) and content.
+   */
+  private loadfile: (path: string, from: string) => Promise<[string, string]>;
+  /**
+   *
+   * @param loadfile see {@link CompilePlugin.loadfile}
+   */
+  constructor(
+    loadfile: (path: string, from: string) => Promise<[string, string]>
+  ) {
+    this.loadfile = loadfile;
+  }
+
+  // Recursively compiles the input string, replacing @include directives with the contents of the included files. Depth-first, not-parallel.
+  public async compile(
+    input: string,
+    from: string,
+    alreadyIncluded: Set<string> = new Set()
+  ): Promise<string> {
+    const regex: RegExp = /@include\(([^)]+)\)/g;
+    const matches = Array.from(input.matchAll(regex));
+    if (matches.length === 0) return input;
+    const loads = await Promise.all(
+      matches.map(async (match) => {
+        const name = match[1];
+        let id, content;
+        try {
+          [id, content] = await this.loadfile(name, from);
+        } catch {
+          const lineNumber =
+            input.split("\n").findIndex((line) => line.includes(name)) + 1;
+          throw new Error(
+            `File ${name} not found. Is included by ${from}:${lineNumber}.`
+          );
+        }
+        if (!id || !content) return `<!-- Empty content: ${name} -->`;
+        if (alreadyIncluded.has(id)) {
+          return `<!-- Already included: ${id} -->`;
+        }
+        alreadyIncluded.add(id);
+        return `<!-- Start: ${id} -->\n${await this.compile(content, id, alreadyIncluded)}\n<!-- End: ${id} -->`;
+      })
+    );
+    return input.replace(regex, () => loads.shift() || "");
+  }
+}

--- a/packages/argdown-vscode/src/loadfile.ts
+++ b/packages/argdown-vscode/src/loadfile.ts
@@ -1,0 +1,16 @@
+import { Utils, URI } from "vscode-uri";
+import { workspace } from "vscode";
+
+export async function loadFile(
+  path: string,
+  from: string
+): Promise<[string, string]> {
+  const fromURI = URI.parse(from);
+  const dir = Utils.dirname(fromURI);
+
+  const resolvedPath = Utils.resolvePath(dir, path);
+  const data = await workspace.fs.readFile(resolvedPath);
+  const content = Buffer.from(data).toString("utf8");
+
+  return [resolvedPath.toString(), content];
+}

--- a/packages/argdown-vscode/src/preview/IArgdownPreviewState.ts
+++ b/packages/argdown-vscode/src/preview/IArgdownPreviewState.ts
@@ -26,6 +26,7 @@ export interface IArgdownPreviewState {
     settings?: IVizSettings;
   };
   html: {
+    html?: string;
     line: number;
     lineCount?: number;
   };

--- a/packages/argdown-vscode/src/preview/viewProvider/dagreViewProvider.ts
+++ b/packages/argdown-vscode/src/preview/viewProvider/dagreViewProvider.ts
@@ -21,20 +21,25 @@ export const dagreViewProvider: IViewProvider = {
     return `<nav class="submenu">Export as <a data-command="argdown.exportContentToDagreSvg" title="save as svg" href="#">svg</a> | <a data-command="argdown.exportContentToDagrePng" title="save as png" href="#">png</a>
 	</nav>`;
   },
-  generateOnDidChangeTextDocumentMessage: (
+  generateOnDidChangeTextDocumentMessage: async (
     argdownEngine: ArgdownEngine,
     argdownDocument: TextDocument,
     config: ArgdownPreviewConfiguration
   ) => {
-    const map = argdownEngine.exportMapJson(argdownDocument, config);
+    const map = await argdownEngine.exportMapJson(argdownDocument, config);
     const settings =
       config.argdownConfig && config.argdownConfig.dagre
         ? JSON.stringify(config.argdownConfig.dagre)
         : "{}";
     return { map, settings };
   },
-  contributeToInitialState: (s, argdownEngine, argdownDocument, config) => {
-    const map = argdownEngine.getMap(argdownDocument, config);
+  contributeToInitialState: async (
+    s,
+    argdownEngine,
+    argdownDocument,
+    config
+  ) => {
+    const map = await argdownEngine.getMap(argdownDocument, config);
     const settings =
       config.argdownConfig && config.argdownConfig.dagre
         ? config.argdownConfig.dagre

--- a/packages/argdown-vscode/src/preview/viewProvider/htmlViewProvider.ts
+++ b/packages/argdown-vscode/src/preview/viewProvider/htmlViewProvider.ts
@@ -5,31 +5,32 @@ import type { IViewProvider } from "./IViewProvider";
 
 export const htmlViewProvider: IViewProvider = {
   scripts: ["htmlView.js"],
-  generateView: (
-    argdownEngine: ArgdownEngine,
-    argdownDocument: TextDocument,
-    config: ArgdownPreviewConfiguration
-  ) => {
-    const html = argdownEngine.exportHtml(argdownDocument, config);
-    return `${html}<div class="has-line" data-line="${argdownDocument.lineCount}"></div>`;
+  generateView: (_, argdownDocument: TextDocument) => {
+    return `<div id="html-container"></div><div class="has-line" data-line="${argdownDocument.lineCount}"></div>`;
   },
   generateSubMenu: () => {
     return `<nav class="submenu">
 	Export as <a data-command="argdown.exportDocumentToJson" title="save as json" href="#">json</a> | <a data-command="argdown.exportDocumentToHtml" title="save as html" href="#">html</a> | <a data-command="argdown.exportDocumentToDot" title="save as dot" href="#">dot</a> | <a title="save as graphml" data-command="argdown.exportDocumentToGraphML" href="#">graphml</a>
 	</nav>`;
   },
-  generateOnDidChangeTextDocumentMessage: (
+  generateOnDidChangeTextDocumentMessage: async (
     argdownEngine: ArgdownEngine,
     argdownDocument: TextDocument,
     config: ArgdownPreviewConfiguration
   ) => {
-    const html = argdownEngine.exportHtml(argdownDocument, config);
+    const html = await argdownEngine.exportHtml(argdownDocument, config);
     return {
-      html: `${html}<div class="has-line" data-line="${argdownDocument.lineCount}"></div>`
+      html: `<div id="html-container">${html}</div><div class="has-line" data-line="${argdownDocument.lineCount}"></div>`
     };
   },
-  contributeToInitialState: (s, _argdownEngine, argdownDocument) => {
+  contributeToInitialState: async (
+    s,
+    argdownEngine,
+    argdownDocument,
+    config: ArgdownPreviewConfiguration
+  ) => {
     s.html.lineCount = argdownDocument.lineCount;
+    s.html.html = await argdownEngine.exportHtml(argdownDocument, config);
     return s;
   }
 };

--- a/packages/argdown-vscode/syntaxes/argdown.tmLanguage.json
+++ b/packages/argdown-vscode/syntaxes/argdown.tmLanguage.json
@@ -537,6 +537,26 @@
     },
     {
       "include": "#data"
+    },
+    {
+      "begin": "@include\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.control.include.argdown"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "keyword.control.include.argdown"
+        }
+      },
+      "patterns": [
+        {
+          "match": "[^)]+",
+          "name": "entity.name.filename.argdown"
+        }
+      ]
     }
   ],
   "scopeName": "text.html.argdown"

--- a/packages/argdown-vscode/themes/argdown-dark.json
+++ b/packages/argdown-vscode/themes/argdown-dark.json
@@ -110,7 +110,24 @@
       "name": "Argdown Tags",
       "scope": ["meta.tag.argdown"],
       "settings": {
-        "foreground": "#777777"
+        "foreground": "#777777",
+        "fontStyle": ""
+      }
+    },
+    {
+      "name": "Include Keyword",
+      "scope": "keyword.control.include.argdown",
+      "settings": {
+        "foreground": "#9CDCFE",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Include Filename",
+      "scope": "entity.name.filename.argdown",
+      "settings": {
+        "foreground": "#CE9178",
+        "fontStyle": "italic"
       }
     }
   ]

--- a/packages/argdown-vscode/themes/argdown-light.json
+++ b/packages/argdown-vscode/themes/argdown-light.json
@@ -112,6 +112,22 @@
       "settings": {
         "foreground": "#777777"
       }
+    },
+    {
+      "name": "Include Keyword",
+      "scope": "keyword.control.include.argdown",
+      "settings": {
+        "foreground": "#0362FF",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Include Filename",
+      "scope": "entity.name.filename.argdown",
+      "settings": {
+        "foreground": "#7E0E7F",
+        "fontStyle": "italic"
+      }
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,7 +380,7 @@ __metadata:
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.7"
-    vscode-languageserver: "npm:^9.0.1"
+    vscode-languageserver: "npm:^10.1.0"
     vscode-languageserver-textdocument: "npm:1.0.12"
     vscode-uri: "npm:^3.1.0"
   bin:
@@ -22547,6 +22547,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vscode-jsonrpc@npm:9.0.1":
+  version: 9.0.1
+  resolution: "vscode-jsonrpc@npm:9.0.1"
+  checksum: 10c0/6ca63393dd78675ed33b5537c147e673865557ff93915cd5189ceae039ca7fe01808ffd9a14016732d4789f2102a037d68d4216f557c3380d1c7f3ea50fd85b4
+  languageName: node
+  linkType: hard
+
 "vscode-languageclient@npm:9.0.1":
   version: 9.0.1
   resolution: "vscode-languageclient@npm:9.0.1"
@@ -22568,6 +22575,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vscode-languageserver-protocol@npm:3.18.2":
+  version: 3.18.2
+  resolution: "vscode-languageserver-protocol@npm:3.18.2"
+  dependencies:
+    vscode-jsonrpc: "npm:9.0.1"
+    vscode-languageserver-types: "npm:3.18.0"
+  checksum: 10c0/c77862958063b2d6edcdbab7da1abece58b251051338083296c468d5caafc2c249aba63f1a15011d8b8354e145937252520fe6a9632c146606a833bdeae9784c
+  languageName: node
+  linkType: hard
+
 "vscode-languageserver-textdocument@npm:1.0.12":
   version: 1.0.12
   resolution: "vscode-languageserver-textdocument@npm:1.0.12"
@@ -22582,14 +22599,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-languageserver@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "vscode-languageserver@npm:9.0.1"
+"vscode-languageserver-types@npm:3.18.0":
+  version: 3.18.0
+  resolution: "vscode-languageserver-types@npm:3.18.0"
+  checksum: 10c0/d8c51cd286cc55b4c1f333e87fa3cefc66d2aae8c65f6209e7ecf88032d3326308b333d62b05243c194be8a3304760445b87630b298116c6c612607f011b4de0
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "vscode-languageserver@npm:10.1.0"
   dependencies:
-    vscode-languageserver-protocol: "npm:3.17.5"
+    vscode-languageserver-protocol: "npm:3.18.2"
   bin:
     installServerIntoExtension: bin/installServerIntoExtension
-  checksum: 10c0/8a0838d77c98a211c76e54bd3a6249fc877e4e1a73322673fb0e921168d8e91de4f170f1d4ff7e8b6289d0698207afc6aba6662d4c1cd8e4bd7cae96afd6b0c2
+  checksum: 10c0/5c3d903be4aab4828e1abd9ea5be938489f6f6a850ae0929618a131ef985ad0c77bd233a4045ac559d805201f8fddf83316f4967386102fa409a4addae77a652
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,7 @@ __metadata:
     "@types/path-browserify": "npm:^1"
     "@vitest/expect": "npm:^4.1.0"
     esbuild: "npm:^0.27.4"
+    fast-glob: "npm:^3.3.3"
     npm-run-all: "npm:^4.1.5"
     path-browserify: "npm:^1.0.1"
     rimraf: "npm:^6.0.1"
@@ -381,6 +382,7 @@ __metadata:
     vitest: "npm:^4.1.7"
     vscode-languageserver: "npm:^9.0.1"
     vscode-languageserver-textdocument: "npm:1.0.12"
+    vscode-uri: "npm:^3.1.0"
   bin:
     language-server: ./dist/server.node.js
   languageName: unknown


### PR DESCRIPTION
# Multifile Argdown
This adds multifile support to the vscode extension and language server. It closes #150 


# How does this work
Inside of an argdownfile you can specify @include and / or @main. An argdown file has access to every descendant of it (every file that is directly or indirectly @included). A descendant (A) can define at most 1 other file (B) via @main. Afterwards it gains access to everything that the other file (B) has access to. However those definitions are not accessible for files that @include that the descendant (A).

## Formal definition
Let's say every Argdown file is a node. Then @include defines directed edges between nodes. We require that this yields a DAG G = <V,E>. We also require that v may only declare node v° as main file if v is a descendant of v°.

If a file v declares no main file, then v has access to all definitions defined in any descendant u of v (i.e., every file u such that there is a directed path from v to u).

If a file v declares a main file v°, then v has access to all definitions defined in any descendant of v°.

# Architectural Problems
We can not add this inside of @argdown/core because we do not have access to the file system. Instead this should belong inside of @argdown/node but the vs-code extension can not use @argdown/node because we need to support complete browser environments. So we have 2 options.
1. add browser bundles to @argdown/node by refactoring it and adding a bundler
2. outsource this to another package that is only defined inside of vs-code. 

I think using option 2 is the safest bet and we can refactor @argdown/node in the future and migrate the custom plugin into this package then.


# Plan
We can not edit @argdown/core, because we can not support browser environments there. Therefore we need plugins that will be defined inside of dependent packages (argdown-vscode, argdown-language-server).

To resolve the mapping issue between included files and their source files, we will use source maps. The source maps are orientated on this spec: https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit?tab=t.0#heading=h.1ce2c87bpj24

Inside of a dependent package (argdown-vscode, argdown-language-server), we have a MultiFilePlugin that replaces the @include or @main strings with the actual content of file, that will be loaded from the file system. It will also generate source maps for the included files and output them to the response field "sourceMap". Then we can use the source maps to map the included files back to their source files to use language server features like hover, go to definition, etc.

## Simple example of source maps
**File A (main.argdown):**
```
0-10: @include(header.argdown)
11-15: My statement
```

**File B (header.argdown):**
```
0-10: # Header
11-20: Some content
```

**after @include replacement:**
```
0-10:  # Header       ← from header.argdown
11-20: Some content
21-25: My statement  ← from main.argdown
```

### Source Map

```typescript
interface Mapping {
  resolved: { start: 0, end: 20, file: "header.argdown", original: { start: 0, end: 20 } }
  resolved: { start: 21, end: 25, file: "main.argdown", original: { start: 11, end: 15 } }
}
```

### Using the Source Map
```typescript
// user clicks in main.argdown on position 5 to see were the definition is defined
const originalPos = sourceMap.resolve("main.argdown", 5);
// → { file: "header.argdown", position: 0 }

// user clicks in header.argdown on position 5 to see were the definition is used
const resolvedPos = sourceMap.resolveToMain("header.argdown", 5);
// → { file: "main.argdown", position: 2 }
